### PR TITLE
Rename JNI class references, and D-Bus object paths

### DIFF
--- a/patches.py
+++ b/patches.py
@@ -43,6 +43,9 @@ def get_source_patches(name: str, cap_name: str) -> list[tuple[str, str]]:
         ("re.frida.helper", f"re.{name}.helper"),
         ("re.frida.Gadget", f"re.{name}.Gadget"),
         ("package re.frida;", f"package re.{name};"),
+        # Also rename JNI class references, and D-Bus object paths.
+        ("re/frida/Helper", f"re/{name}/Helper"),
+        ("re/frida/Gadget", f"re/{name}/Gadget"),
 
         # --- D-Bus / service identifier ---
         ("re.frida.server", f"re.{name}.server"),


### PR DESCRIPTION
# Rename JNI class references, and D-Bus object paths

fix #5 

When frida starts, it will call AndroidHelper through JNI.

https://github.com/frida/frida-core/blob/a62376a3d6319fcdbc8c6b81b6879634be71929b/src/linux/linux-host-session.vala#L721-L722

So we should also replace `re/frida/Helper`.

By the way,D-Bus also use `re/frida/Helper` and `re/frida/Gadget` object path.

## Server
<img width="660" height="467" alt="image" src="https://github.com/user-attachments/assets/3af9df3f-85ba-4c53-b6b6-138f44e82afb" />

## Gadget
<img width="647" height="442" alt="image" src="https://github.com/user-attachments/assets/e57e7a5b-4ffb-42e9-8285-2490948e1507" />
