### PR TITLE
Fix release publishing without checkout

### DIFF
--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -108,6 +108,7 @@ jobs:
       CUSTOM_NAME: ${{ needs.resolve.outputs.name }}
       CUSTOM_PORT: ${{ needs.resolve.outputs.port }}
       FRIDA_VERSION: ${{ needs.resolve.outputs.version }}
+      GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
 
     steps:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -108,6 +108,12 @@ def test_release_publishes_every_file_covered_by_sha256sums() -> None:
     assert "release-assets/*.gz" not in release_command
 
 
+def test_release_targets_repository_without_requiring_checkout() -> None:
+    text = workflow_text("scheduled-build.yml")
+    release_job = text.split("  release:", 1)[1]
+    assert "GH_REPO: ${{ github.repository }}" in release_job
+
+
 def test_dependabot_updates_pinned_actions_weekly() -> None:
     text = Path(".github/dependabot.yml").read_text(encoding="utf-8")
     assert "package-ecosystem: github-actions" in text


### PR DESCRIPTION
## Root cause

The release job deliberately runs without a checkout, but `gh release create` had neither `GH_REPO` nor `--repo`. After successful build, checksum verification, and attestation, GitHub CLI failed while trying to discover a repository from `.git`.

## Fix

- provide `GH_REPO` from the trusted workflow repository context
- add a regression contract proving the no-checkout release job has an explicit repository target

## Validation

- 101 pytest tests
- Ruff, format, mypy, Node and Bash syntax
- actionlint with ShellCheck

Follow-up to #9 and failed release run 29869229454.
