### PR TITLE
chore(deps): update remaining GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,12 +36,12 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@08d09a53f0f5d694f253bd25732e4429c9e9337f # v3
+        uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Analyze
-        uses: github/codeql-action/analyze@08d09a53f0f5d694f253bd25732e4429c9e9337f # v3
+        uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -142,7 +142,7 @@ jobs:
           PY
 
       - name: Attest release assets
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: release-assets/*
 

--- a/tests/test_repository_contract.py
+++ b/tests/test_repository_contract.py
@@ -31,7 +31,7 @@ def test_readme_does_not_overclaim_protocol_or_version_support() -> None:
 
 def test_codeql_is_pinned_and_has_minimal_permissions() -> None:
     codeql = Path(".github/workflows/codeql.yml").read_text(encoding="utf-8")
-    sha = "08d09a53f0f5d694f253bd25732e4429c9e9337f"
+    sha = "e0647621c2984b5ed2f768cb892365bf2a616ad1"
     assert codeql.count(f"github/codeql-action/init@{sha}") == 1
     assert codeql.count(f"github/codeql-action/analyze@{sha}") == 1
     assert "contents: read" in codeql


### PR DESCRIPTION
## Summary

- update `actions/setup-python` from v5 to v7.0.0 in CI and build workflows
- update `github/codeql-action` from v3 to v4.37.2
- update `actions/attest-build-provenance` from v3 to v4.1.1
- refresh the pinned CodeQL repository contract

## Why

The final Actions audit found Node.js 20 deprecation warnings for setup-python and CodeQL. These updates also clear the remaining stale official Action pin that was outside Dependabot's five-PR weekly limit.

## Validation

- targeted repository contract: 1 passed
- full Python suite: 101 passed
- Ruff: passed
- mypy: passed
- JavaScript syntax: passed
- shell syntax: passed
- actionlint v1.7.12: passed
