### PR TITLE
Harden runtime markers and Android verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ The repository separates three kinds of evidence:
 1. Unit and fixture tests validate input handling, exact Frida 17.16.3 source
    patch contracts, DEX rebuilding, artifact promotion, metadata, workflows,
    and failure behavior.
-2. `build.py --verify` requires both Server and Gadget, then rejects known
-   forbidden runtime markers before publishing either artifact.
+2. `build.py --verify` requires both Server and Gadget, strips the staged
+   Gadget, then rejects known forbidden runtime markers before publishing
+   either artifact.
 3. `scripts/android_smoke.py` exercises a built artifact on one rooted device:
-   stock-client enumeration, spawn, attach, Java bridge assertions, `/proc`
-   scans, and a separately loaded Gadget.
+   authenticated abstract-UNIX transport, stock-client RPC, spawn, attach,
+   Java bridge assertions, `/proc` checks, an external root memory scan, and a
+   separately loaded Gadget.
 
 A passing source test or byte scan is not equivalent to runtime stealth. Claims
 about Android behavior should include the generated, redacted smoke-test report.
@@ -35,7 +37,8 @@ Run **Build Custom Frida** from the Actions tab. The reusable build workflow:
 - validates every user-controlled build input;
 - downloads Android NDK r29 from Google and checks its published checksum;
 - clones a fresh upstream source tree instead of caching patched source;
-- uploads only after the hard artifact and marker gates pass;
+- strips Gadget symbols and uploads only after the hard artifact and marker
+  gates pass;
 - includes `build-info.json` and `SHA256SUMS` in one build artifact.
 
 The weekly workflow resolves the latest release through the authenticated
@@ -127,9 +130,28 @@ frida-zymbiote
 re/frida/HelperBackend
 frida-server
 frida-helper
+frida-agent
+frida-gadget
+frida-eternal-agent
+frida-generate-certificate
+frida-main-loop
+frida:rpc
+FridaScriptEngine
+GLib-GIO
+GDBusProxy
+GumScript
+Frida/
+gum-js-loop
+gmain\0
+gdbus\0
+pool-frida
+pool-spawner
+jit-cache\0
 ```
 
-Capital `Frida` and allowlisted protocol strings are not verifier failures.
+The exact public API string `Frida\0` and allowlisted `re.frida.*` protocol
+identifiers remain intentionally preserved. The HTTP/Inspector prefix
+`Frida/` is a verifier failure and is renamed independently.
 
 ## Rooted Android acceptance
 
@@ -152,9 +174,12 @@ python3 scripts/android_smoke.py \
 
 The package must be an installed Java application you are authorized to test.
 The harness compiles `test_comprehensive.js` with the explicit
-`frida-java-bridge` required by Frida 17, starts Server through a forwarded TCP
-port, then compiles a minimal native loader and exercises Gadget on a separate
-port. It cleans up its processes and forwards on exit.
+`frida-java-bridge` required by Frida 17. Server and Gadget each listen on a
+random authenticated abstract-UNIX socket; their host TCP ports exist only as
+ADB forwards and no device TCP listener is exposed. The harness also compiles
+an ABI-matched root probe that scans the mapped agent and Gadget images through
+`/proc/<pid>/mem`, outside Frida's own process view. It cleans up its processes,
+forwards, and remote test directory on exit.
 
 Frida Gadget configuration must be named next to the library as
 `lib<name>-gadget.config.so`; the harness generates and deploys this file.
@@ -194,6 +219,8 @@ tests/                   Unit, contract, fixture, and workflow tests
 - `--temp-fixes` changes runtime behavior and remains opt-in.
 - Marker absence does not prove resistance to behavioral, integrity, timing, or
   application-specific detection.
+- The external memory gate scans the mapped agent/Gadget images for its explicit
+  marker set; it is not a general-purpose scan of every anonymous heap page.
 - Frida 17 raw agents need explicit bridge imports or bundling. The harness uses
   `frida.Compiler`; the Frida REPL and tracer provide their own bundled bridges.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ random authenticated abstract-UNIX socket; their host TCP ports exist only as
 ADB forwards and no device TCP listener is exposed. The harness also compiles
 an ABI-matched root probe that scans the mapped agent and Gadget images through
 `/proc/<pid>/mem`, outside Frida's own process view. It cleans up its processes,
-forwards, and remote test directory on exit.
+forwards, and remote test directory on exit. The `/proc` gate also rejects
+legacy `linjector` file-descriptor names and a non-zero `TracerPid`.
 
 Frida Gadget configuration must be named next to the library as
 `lib<name>-gadget.config.so`; the harness generates and deploys this file.
@@ -219,6 +220,10 @@ tests/                   Unit, contract, fixture, and workflow tests
 - `--temp-fixes` changes runtime behavior and remains opt-in.
 - Marker absence does not prove resistance to behavioral, integrity, timing, or
   application-specific detection.
+- Stock-client compatibility preserves public ABI/protocol behavior. Active
+  protocol probing and code-integrity checks may still identify instrumentation.
+- This builder does not hide root, automated app launch, Interceptor code
+  changes, user-script strings, or failures reported by remote attestation.
 - The external memory gate scans the mapped agent/Gadget images for its explicit
   marker set; it is not a general-purpose scan of every anonymous heap page.
 - Frida 17 raw agents need explicit bridge imports or bundling. The harness uses

--- a/build.py
+++ b/build.py
@@ -42,6 +42,7 @@ from patches import (
     get_binary_patches,
     get_binary_string_patches,
     get_internal_patches,
+    get_memory_signature_patches,
     get_port_patches,
     get_required_file_patches,
     get_rollback_patches,
@@ -70,6 +71,23 @@ FORBIDDEN_BINARY_MARKERS = (
     b"re/frida/HelperBackend",
     b"frida-server",
     b"frida-helper",
+    b"frida-agent",
+    b"frida-gadget",
+    b"frida-eternal-agent",
+    b"frida-generate-certificate",
+    b"frida-main-loop",
+    b"frida:rpc",
+    b"FridaScriptEngine",
+    b"GLib-GIO",
+    b"GDBusProxy",
+    b"GumScript",
+    b"Frida/",
+    b"gum-js-loop",
+    b"gmain\x00",
+    b"gdbus\x00",
+    b"pool-frida",
+    b"pool-spawner",
+    b"jit-cache\x00",
 )
 ZYMBIOTE_ARCHITECTURES = ("arm", "arm64", "x86", "x86_64")
 ZYMBIOTE_SOCKET_FIELD_SIZE = 64
@@ -341,6 +359,22 @@ def validate_ndk(ndk_dir: Path) -> Path:
         )
         raise BuildError(f"NDK revision mismatch: expected {NDK_REVISION}, found {actual}")
     return ndk_dir
+
+
+def find_llvm_strip(ndk_dir: Path) -> Path:
+    """Locate the host llvm-strip shipped with the validated Android NDK."""
+    candidates = sorted(
+        candidate
+        for prebuilt in (ndk_dir / "toolchains" / "llvm" / "prebuilt").glob("*")
+        for candidate in (
+            prebuilt / "bin" / "llvm-strip",
+            prebuilt / "bin" / "llvm-strip.exe",
+        )
+        if candidate.is_file()
+    )
+    if not candidates:
+        raise BuildError(f"NDK llvm-strip is missing under {ndk_dir}")
+    return candidates[0]
 
 
 def verify_file_checksum(path: Path, expected: str, algorithm: str) -> None:
@@ -701,7 +735,7 @@ def apply_targeted_patches(frida_dir: Path, custom_name: str, frida_major: int):
     if memfd_file.exists():
         count = replace_in_file(memfd_file, memfd_cfg["old"], memfd_cfg["new"])
         if count:
-            log(f"  memfd_create -> 'jit-cache' in {memfd_cfg['file']}", "OK")
+            log(f"  memfd_create -> 'jit-code-cache' in {memfd_cfg['file']}", "OK")
         else:
             log(f"  memfd_create: pattern not found in {memfd_cfg['file']}", "WARN")
     else:
@@ -869,25 +903,86 @@ def find_dex_regions(data: bytes) -> list[tuple[int, int]]:
     return regions
 
 
-def replace_bytes_outside_regions(
-    data: bytes, old: bytes, new: bytes, skip_regions: list[tuple[int, int]]
+def find_elf_alloc_regions(data: bytes) -> list[tuple[int, int]]:
+    """Return file ranges for ELF SHF_ALLOC sections, or the full range for non-ELF data."""
+    if not data.startswith(b"\x7fELF"):
+        return [(0, len(data))]
+    if len(data) < 64:
+        raise BuildError("ELF header is truncated")
+    if data[5] != 1:
+        raise BuildError("Only little-endian ELF artifacts are supported")
+
+    elf_class = data[4]
+    if elf_class == 2:
+        section_table_offset = struct.unpack_from("<Q", data, 0x28)[0]
+        section_header_size = struct.unpack_from("<H", data, 0x3A)[0]
+        section_count = struct.unpack_from("<H", data, 0x3C)[0]
+        minimum_section_header_size = 64
+        flags_offset, flags_format = 8, "<Q"
+        file_offset_offset, size_offset, value_format = 24, 32, "<Q"
+    elif elf_class == 1:
+        section_table_offset = struct.unpack_from("<I", data, 0x20)[0]
+        section_header_size = struct.unpack_from("<H", data, 0x2E)[0]
+        section_count = struct.unpack_from("<H", data, 0x30)[0]
+        minimum_section_header_size = 40
+        flags_offset, flags_format = 8, "<I"
+        file_offset_offset, size_offset, value_format = 16, 20, "<I"
+    else:
+        raise BuildError(f"Unsupported ELF class: {elf_class}")
+
+    if section_table_offset == 0 or section_header_size < minimum_section_header_size:
+        raise BuildError("ELF section table is missing or invalid")
+    if section_table_offset + section_header_size > len(data):
+        raise BuildError("ELF section table starts outside the artifact")
+    if section_count == 0:
+        section_count = int(
+            struct.unpack_from(value_format, data, section_table_offset + size_offset)[0]
+        )
+    if section_count == 0:
+        raise BuildError("ELF contains no section headers")
+    if section_table_offset + (section_count * section_header_size) > len(data):
+        raise BuildError("ELF section table extends outside the artifact")
+
+    regions = []
+    for index in range(section_count):
+        header = section_table_offset + (index * section_header_size)
+        section_type = struct.unpack_from("<I", data, header + 4)[0]
+        flags = struct.unpack_from(flags_format, data, header + flags_offset)[0]
+        file_offset = int(struct.unpack_from(value_format, data, header + file_offset_offset)[0])
+        size = int(struct.unpack_from(value_format, data, header + size_offset)[0])
+        if flags & 0x2 == 0 or section_type == 8 or size == 0:
+            continue
+        if file_offset + size > len(data):
+            raise BuildError(f"ELF allocated section {index} extends outside the artifact")
+        regions.append((file_offset, file_offset + size))
+    if not regions:
+        raise BuildError("ELF contains no file-backed SHF_ALLOC sections")
+    return regions
+
+
+def replace_bytes_in_regions(
+    data: bytes,
+    old: bytes,
+    new: bytes,
+    include_regions: list[tuple[int, int]],
+    skip_regions: list[tuple[int, int]],
 ) -> tuple[bytes, int]:
-    """Replace byte pattern in data, skipping protected regions.
-    Returns (modified_data, replacement_count)."""
+    """Replace a same-length pattern only inside included, non-protected file ranges."""
     assert len(old) == len(new), "Replacement must be same length"
     result = bytearray(data)
     count = 0
-    idx = 0
+    offset = 0
     while True:
-        pos = data.find(old, idx)
-        if pos == -1:
+        position = data.find(old, offset)
+        if position == -1:
             break
-        # Check if this position falls inside any protected region
-        in_protected = any(start <= pos < end for start, end in skip_regions)
-        if not in_protected:
-            result[pos : pos + len(new)] = new
+        end = position + len(old)
+        included = any(start <= position and end <= stop for start, stop in include_regions)
+        protected = any(start <= position < stop for start, stop in skip_regions)
+        if included and not protected:
+            result[position:end] = new
             count += 1
-        idx = pos + 1
+        offset = position + 1
     return bytes(result), count
 
 
@@ -898,17 +993,20 @@ def apply_binary_patches(binary_path: Path, custom_name: str, extended: bool = F
     original_size = len(data)
     patched = False
 
-    # Find embedded DEX regions to protect
-    dex_regions = find_dex_regions(data) if extended else []
+    alloc_regions = find_elf_alloc_regions(data)
+    dex_regions = find_dex_regions(data)
 
-    # Standard thread name patches (safe — these patterns don't appear in DEX)
-    for old_hex, new_hex, description in get_binary_patches():
+    runtime_patches = [*get_memory_signature_patches(custom_name), *get_binary_patches()]
+    for old_hex, new_hex, description in runtime_patches:
         old_bytes = bytes.fromhex(old_hex)
         new_bytes = bytes.fromhex(new_hex)
         if old_bytes in data:
-            data = data.replace(old_bytes, new_bytes)
-            log(f"    {description}", "OK")
-            patched = True
+            data, count = replace_bytes_in_regions(
+                data, old_bytes, new_bytes, alloc_regions, dex_regions
+            )
+            if count:
+                log(f"    {description} ({count}x in SHF_ALLOC)", "OK")
+                patched = True
 
     # Extended: sweep for residual "frida" strings in binary
     # MUST skip DEX regions to avoid corrupting embedded helper DEX
@@ -917,13 +1015,9 @@ def apply_binary_patches(binary_path: Path, custom_name: str, extended: bool = F
             old_bytes = bytes.fromhex(old_hex)
             new_bytes = bytes.fromhex(new_hex)
             if old_bytes in data:
-                if dex_regions:
-                    data, count = replace_bytes_outside_regions(
-                        data, old_bytes, new_bytes, dex_regions
-                    )
-                else:
-                    count = data.count(old_bytes)
-                    data = data.replace(old_bytes, new_bytes)
+                data, count = replace_bytes_in_regions(
+                    data, old_bytes, new_bytes, alloc_regions, dex_regions
+                )
                 if count:
                     log(f"    [ext] {description} ({count}x, skipped DEX regions)", "OK")
                     patched = True
@@ -955,6 +1049,14 @@ def build_frida(frida_dir: Path, ndk_path: Path):
         cwd=frida_dir,
         env={"ANDROID_NDK_ROOT": str(ndk_path)},
     )
+
+
+def strip_binary(binary_path: Path, strip_tool: Path) -> None:
+    """Remove symbols and non-runtime sections from a staged shared library."""
+    before = binary_path.stat().st_size
+    run([strip_tool, "--strip-unneeded", binary_path])
+    after = binary_path.stat().st_size
+    log(f"    stripped {binary_path.name}: {before:,} -> {after:,} bytes", "OK")
 
 
 # ============================================================================
@@ -995,6 +1097,8 @@ def collect_artifacts(
     version: str,
     output_dir: Path,
     extended: bool,
+    *,
+    strip_tool: Path | None = None,
 ) -> list[Path]:
     """Stage, verify, and promote mandatory build artifacts."""
     log(f"Collecting artifacts for {arch}...", "STEP")
@@ -1015,10 +1119,18 @@ def collect_artifacts(
                     log(f"      {f.name} ({f.stat().st_size:,} bytes)", "INFO")
         return None
 
-    def save_artifact(src: Path, out_name: str, stage_dir: Path) -> list[Path]:
+    def save_artifact(
+        src: Path,
+        out_name: str,
+        stage_dir: Path,
+        *,
+        strip: bool = False,
+    ) -> list[Path]:
         out_bin = stage_dir / out_name
         shutil.copy2(src, out_bin)
         os.chmod(out_bin, 0o755)
+        if strip and strip_tool is not None:
+            strip_binary(out_bin, strip_tool)
 
         out_gz = stage_dir / f"{out_name}.gz"
         with out_bin.open("rb") as source, out_gz.open("wb") as raw_output:
@@ -1092,6 +1204,7 @@ def collect_artifacts(
                 gadget,
                 f"{custom_name}-gadget-{version}-android-{arch_short}.so",
                 stage_dir,
+                strip=True,
             ),
         ]
 
@@ -1351,6 +1464,7 @@ Transformations and verification boundaries:
         return
 
     with output_transaction(output_dir) as staged_output:
+        strip_tool = find_llvm_strip(ndk_path)
         # Step 5: Build loop
         for arch in archs:
             log("=" * 60, "HEADER")
@@ -1379,6 +1493,7 @@ Transformations and verification boundaries:
                 version,
                 staged_output,
                 args.extended,
+                strip_tool=strip_tool,
             )
 
         # Step 6: Verification

--- a/build.py
+++ b/build.py
@@ -978,7 +978,7 @@ def replace_bytes_in_regions(
             break
         end = position + len(old)
         included = any(start <= position and end <= stop for start, stop in include_regions)
-        protected = any(start <= position < stop for start, stop in skip_regions)
+        protected = any(position < stop and end > start for start, stop in skip_regions)
         if included and not protected:
             result[position:end] = new
             count += 1

--- a/docs/testing/android-17.16.3.md
+++ b/docs/testing/android-17.16.3.md
@@ -1,7 +1,7 @@
 # Android acceptance: Frida 17.16.3
 
-Tested on 2026-07-21 with locally built Frida 17.16.3 Android arm64
-artifacts. Their exact hashes are recorded below.
+Tested on 2026-07-22 with CI-built Frida 17.16.3 Android arm64 artifacts.
+Their exact hashes are recorded below.
 
 ## Environment
 
@@ -23,13 +23,17 @@ excluded from Git.
 
 | File | SHA-256 |
 |---|---|
-| `oemcodec-server-17.16.3-android-arm64` | `6ab48cda97ecf307c60b73dfaf7ca8a44146773664c3b0abe63493d2f5730bd9` |
-| `oemcodec-server-17.16.3-android-arm64.gz` | `930121e6716e9fadc5e3da7820b816787885c9594bda6a74fe7ddf98409ff9bf` |
-| `oemcodec-gadget-17.16.3-android-arm64.so` | `def6423cdbfa22c6deb01e0f1e4f9ed532f96f498a403623d46670ff3b4fd4fa` |
-| `oemcodec-gadget-17.16.3-android-arm64.so.gz` | `66efc35d0e70160989d88c58c55f97c5b74bd71bc61a45b2a897c971712e608e` |
+| `oemcodec-server-17.16.3-android-arm64` | `68a359b84eac175e6d1e26dab425f53f859b1e54b2c8d0f1d8447c9df737f379` |
+| `oemcodec-server-17.16.3-android-arm64.gz` | `b93213800986eebd96b2389725be8b961e1606750ef730626092c0fdcb7a7bc7` |
+| `oemcodec-gadget-17.16.3-android-arm64.so` | `40a2a15086e8acc70901ca78a3169a29c43bd1ee7a7d6a115a3448fdcfc46a20` |
+| `oemcodec-gadget-17.16.3-android-arm64.so.gz` | `988b40a88bb4afadeae6661657a92c6c8c795d8714022a38d0eac941f8088ae0` |
 
 `SHA256SUMS` independently verified all four files before the device run. The
 uncompressed server and Gadget were identified as AArch64 ELF artifacts.
+`build-info.json` records builder commit
+`b1a9493aa0b26eea8410474a923c56445836d638`, Frida commit
+`954a1c4280fb4301f25f5b3026b407874c7fe5e4`, and frida-core commit
+`5d714719bc0e7cba171c8dd400d4e0bb17db14b7`.
 
 ## Command
 
@@ -38,8 +42,8 @@ authorized device attached:
 
 ```powershell
 .venv\Scripts\python.exe scripts\android_smoke.py `
-  --server output\oemcodec-server-17.16.3-android-arm64 `
-  --gadget output\oemcodec-gadget-17.16.3-android-arm64.so `
+  --server output-dl\oemcodec-server-17.16.3-android-arm64 `
+  --gadget output-dl\oemcodec-gadget-17.16.3-android-arm64.so `
   --name oemcodec `
   --port 27142 `
   --package com.android.calculator2 `
@@ -56,13 +60,15 @@ used port 27143 for the isolated Gadget check.
 | Check | Result | Evidence |
 |---|---|---|
 | Root precondition | PASS | `su -c id` returned UID 0. |
-| Stock client to Server | PASS | Frida 17.16.3 enumerated 122 processes in the latest run. |
+| Stock client to Server | PASS | Frida 17.16.3 enumerated 153 processes in the latest run. |
 | Spawn, attach, and resume | PASS | The calculator process completed the scripted lifecycle. |
 | Java bridge and hook installation | PASS | `Java.available` was true and the structured agent reported no failures. |
-| `/proc` maps, file descriptors, and thread names | PASS | No forbidden `frida-server`, `frida-helper`, or `frida-zymbiote` marker was found. |
-| Zymbiote socket rename | PASS | A rooted live scan found the custom `oemcodec-zymbiote` socket and no `frida-zymbiote` socket. |
+| Authenticated transport | PASS | Server and Gadget used separate randomized abstract Unix sockets, origins, and tokens; neither exposed a device TCP listener. |
+| `/proc` maps, file descriptors, status, and thread names | PASS | No forbidden runtime/thread marker or `linjector` descriptor was found, and `TracerPid` was zero. |
+| External Server memory scan | PASS | A separate rooted native scanner inspected 9 readable ranges (7 executable); all 14 runtime markers had zero matches. |
 | Stock client to Gadget | PASS | The separately loaded Gadget accepted Frida 17.16.3, attached to its process, loaded a probe script, received its structured result, and detached. |
-| Cleanup | PASS | No test process, ADB forward, or tested socket marker remained after exit. |
+| External Gadget memory scan | PASS | A separate rooted native scanner inspected 9 readable ranges (7 executable); all 14 runtime markers had zero matches. |
+| Cleanup | PASS | Exact executable paths were terminated gracefully; an independent follow-up found no test process, directory, Unix socket, open file, or ADB forward. |
 
 Redacted structured result:
 
@@ -72,13 +78,22 @@ Redacted structured result:
   "gadget": {
     "abi": "arm64-v8a",
     "api_level": 34,
+    "memory": {
+      "executable": 7,
+      "ranges": 9
+    },
     "process_count": 1,
     "script_loaded": true
   },
   "server": {
     "java_available": true,
+    "memory": {
+      "executable": 7,
+      "ranges": 9
+    },
     "script_failures": []
   },
+  "server_process_count": 153,
   "status": "passed"
 }
 ```

--- a/patches.py
+++ b/patches.py
@@ -194,6 +194,16 @@ def get_required_file_patches(name: str) -> list[RequiredFilePatch]:
             f'"{name}-main-loop"',
         ),
         RequiredFilePatch(
+            "subprojects/frida-core/src/host-session-service.vala",
+            "Process with pid %u either refused to load frida-agent, ",
+            f"Process with pid %u either refused to load {name}-agent, ",
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-gum/bindings/gumjs/guminspectorserver.c",
+            '"Frida/v" FRIDA_VERSION',
+            f'"{cap_name}/v" FRIDA_VERSION',
+        ),
+        RequiredFilePatch(
             "subprojects/frida-core/lib/base/socket.vala",
             '"Frida/',
             f'"{cap_name}/',

--- a/patches.py
+++ b/patches.py
@@ -11,13 +11,14 @@ Patch categories:
 
 Source verification notes (17.16.3):
   - g_set_prgname("frida") does NOT exist — removed
-  - frida-gadget-tcp/unix do NOT exist — removed
+  - Gadget worker names are frida-gadget, frida-gadget-tcp-%u, and frida-gadget-unix
   - memfd_create is in lib/base/linux.vala, NOT frida-helper-backend.vala
   - SELinux labels are in linjector.vala, NOT frida-helper-backend.vala
   - cloak.vala uses GOT slot patching, NOT Gum.Interceptor
   - gumprocess-linux.c uses entry->name, NOT details.name
 """
 
+import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -35,6 +36,8 @@ class RequiredFilePatch:
 def get_required_file_patches(name: str) -> list[RequiredFilePatch]:
     """Return exact Frida source patches required for Android runtime correctness."""
     linux_host_session = "subprojects/frida-core/src/linux/linux-host-session.vala"
+    cap_name = name[0].upper() + name[1:]
+    rpc_tag_expression = "String.fromCharCode(102, 114, 105, 100, 97, 58, 114, 112, 99)"
     return [
         RequiredFilePatch(
             linux_host_session,
@@ -101,6 +104,116 @@ def get_required_file_patches(name: str) -> list[RequiredFilePatch]:
     gum_interceptor_replace (interceptor, gum_original_sigaction,
         gum_exceptor_backend_replacement_sigaction, NULL, &options);""",
             "    (void) options; /* Signal interception intentionally disabled. */",
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/lib/base/rpc.vala",
+            '.add_string_value ("frida:rpc")',
+            ".add_string_value (make_rpc_tag ())",
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/lib/base/rpc.vala",
+            'json.index_of ("\\"frida:rpc\\"")',
+            'json.index_of ("\\"%s\\"".printf (make_rpc_tag ()))',
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/lib/base/rpc.vala",
+            'type != "frida:rpc"',
+            "type != make_rpc_tag ()",
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/lib/base/rpc.vala",
+            "\t\tprivate class PendingResponse {",
+            """\t\tprivate static string make_rpc_tag () {
+\t\t\treturn "%c%c%c%c%c%c%c%c%c".printf (102, 114, 105, 100, 97, 58, 114, 112, 99);
+\t\t}
+
+\t\tprivate class PendingResponse {""",
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/src/barebone/script-runtime/message-dispatcher.ts",
+            "export class MessageDispatcher {",
+            f"const rpcTag = {rpc_tag_expression};\n\nexport class MessageDispatcher {{",
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/src/barebone/script-runtime/message-dispatcher.ts",
+            '"frida:rpc"',
+            "rpcTag",
+            minimum=3,
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-gum/bindings/gumjs/runtime/message-dispatcher.js",
+            "export function MessageDispatcher() {",
+            f"const rpcTag = {rpc_tag_expression};\n\nexport function MessageDispatcher() {{",
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-gum/bindings/gumjs/runtime/message-dispatcher.js",
+            "'frida:rpc'",
+            "rpcTag",
+            minimum=4,
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-gum/bindings/gumjs/runtime/worker.js",
+            "export class Worker {",
+            f"const rpcTag = {rpc_tag_expression};\n\nexport class Worker {{",
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-gum/bindings/gumjs/runtime/worker.js",
+            "'frida:rpc'",
+            "rpcTag",
+            minimum=2,
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/lib/gadget/gadget-glue.c",
+            'g_thread_new ("frida-gadget",',
+            f'g_thread_new ("{name}-gadget",',
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/lib/gadget/gadget.vala",
+            '"frida-gadget-tcp-%u"',
+            f'"{name}-gadget-tcp-%u"',
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/lib/gadget/gadget.vala",
+            '"frida-gadget-unix"',
+            f'"{name}-gadget-unix"',
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/lib/agent/agent.vala",
+            '"frida-eternal-agent"',
+            f'"{name}-eternal-agent"',
+            minimum=3,
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/lib/base/p2p.vala",
+            '"frida-generate-certificate"',
+            f'"{name}-generate-certificate"',
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/src/frida-glue.c",
+            '"frida-main-loop"',
+            f'"{name}-main-loop"',
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/lib/base/socket.vala",
+            '"Frida/',
+            f'"{cap_name}/',
+            minimum=3,
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/lib/payload/portal-client.vala",
+            "frida-gadget",
+            f"{name}-gadget",
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/src/droidy/injector.vala",
+            "frida-gadget-",
+            f"{name}-gadget-",
+            minimum=2,
+        ),
+        RequiredFilePatch(
+            "subprojects/frida-core/src/droidy/droidy-host-session.vala",
+            "frida-gadget.so",
+            f"{name}-gadget.so",
         ),
     ]
 
@@ -273,14 +386,14 @@ MEMFD_PATCHES = {
     16: {
         "file": "src/linux/frida-helper-backend.vala",
         "old": "return Linux.syscall (SysCall.memfd_create, name, flags);",
-        "new": 'return Linux.syscall (SysCall.memfd_create, "jit-cache", flags);',
+        "new": 'return Linux.syscall (SysCall.memfd_create, "jit-code-cache", flags);',
     },
     # Frida 17.x: memfd_create moved to lib/base/linux.vala
     # Verified: exact function signature and enum name
     17: {
         "file": "lib/base/linux.vala",
         "old": "return Linux.syscall (LinuxSyscall.MEMFD_CREATE, name, flags);",
-        "new": 'return Linux.syscall (LinuxSyscall.MEMFD_CREATE, "jit-cache", flags);',
+        "new": 'return Linux.syscall (LinuxSyscall.MEMFD_CREATE, "jit-code-cache", flags);',
     },
 }
 
@@ -329,6 +442,23 @@ def get_binary_patches() -> list[tuple[str, str, str]]:
             "pool-spawner\\0 -> pool-spoiler\\0",
         ),
     ]
+
+
+def get_memory_signature_patches(name: str) -> list[tuple[str, str, str]]:
+    """Return deterministic same-length aliases for mapped runtime signatures."""
+    markers = ("FridaScriptEngine", "GLib-GIO", "GDBusProxy", "GumScript")
+    patches = []
+    for marker in markers:
+        digest = hashlib.sha256(f"{name}:{marker}".encode()).hexdigest()
+        replacement = ("x" + digest)[: len(marker)]
+        patches.append(
+            (
+                marker.encode().hex(),
+                replacement.encode().hex(),
+                f'{marker} -> per-profile runtime alias "{replacement}"',
+            )
+        )
+    return patches
 
 
 # ============================================================================
@@ -472,15 +602,19 @@ Build transformations:
 
 [required source and artifact contracts]
  - Server, helper, Gadget, agent, JNI package, and zymbiote socket identifiers
- - Selected thread and memfd names, SELinux labels, and D-Bus service identifier
+ - RPC wire tag construction without a contiguous marker in mapped code
+ - Current Server, Gadget, agent, GLib, and GDBus thread names
+ - Android-compatible jit-code-cache memfd name, SELinux labels, and D-Bus service identifier
+ - Same-length per-profile aliases for mapped FridaScriptEngine/GLib/GDBus/Gum markers
  - frida_agent_main generated symbol, patched in both caller and definition
 
 [optional with --extended]
  - Configured listening port, selected GType names, and temporary path prefixes
- - Same-length residual byte replacements outside protected DEX regions
+ - Same-length residual byte replacements in runtime ELF sections outside protected DEX regions
 
 [hard output gate]
  - Rejects the explicit FORBIDDEN_BINARY_MARKERS set in Server and Gadget
+ - Strips staged Gadget symbols and non-runtime sections before verification/compression
 
 Compatibility identifiers intentionally preserved:
  - D-Bus protocol interfaces under re.frida.* and /re/frida/GadgetSession
@@ -488,4 +622,5 @@ Compatibility identifiers intentionally preserved:
  - Allowlisted protocol strings; verification does not claim every substring is removed
 
 Runtime compatibility and observation claims require scripts/android_smoke.py evidence.
+The smoke test uses authenticated abstract-UNIX endpoints and an external root memory scanner.
 """

--- a/scripts/android_smoke.py
+++ b/scripts/android_smoke.py
@@ -129,7 +129,7 @@ def require_single_device(adb_output: str) -> str:
 def assert_interactive_device(power_state: str, window_policy: str) -> None:
     if "mWakefulness=Awake" not in power_state:
         raise SmokeFailure("Android device must be awake before spawn acceptance")
-    if "mInputRestricted=true" in window_policy:
+    if "mInputRestricted=false" not in window_policy:
         raise SmokeFailure("Android device must be unlocked before spawn acceptance")
 
 
@@ -224,7 +224,7 @@ def run_command(
 def adb(
     serial: str, *arguments: str | os.PathLike[str], check: bool = True
 ) -> subprocess.CompletedProcess[str]:
-    return run_command(["adb", "-s", serial, *arguments], check=check)
+    return run_command(["adb", "-s", serial, *arguments], check=check, redact=(serial,))
 
 
 def root_shell(
@@ -653,11 +653,50 @@ def _exercise_gadget(
 def _cleanup(config: AndroidSmokeConfig, serial: str) -> None:
     remote_server = f"{REMOTE_DIR}/{config.name}-server"
     remote_loader = f"{REMOTE_DIR}/gadget-loader"
-    root_shell(serial, f"pkill -9 -f {remote_server} || true", check=False)
-    root_shell(serial, f"pkill -9 -f {remote_loader} || true", check=False)
-    root_shell(serial, f"rm -rf -- {REMOTE_DIR}", check=False)
+    remote_processes = (remote_server, remote_loader)
+    failures: list[str] = []
+
+    for remote_process in remote_processes:
+        result = root_shell(
+            serial,
+            f"pkill -9 -f '^{remote_process}([[:space:]]|$)'",
+            check=False,
+        )
+        if result.returncode not in (0, 1):
+            failures.append(f"stop {Path(remote_process).name} (exit {result.returncode})")
+
+    remove_result = root_shell(serial, f"rm -rf -- {REMOTE_DIR}", check=False)
+    if remove_result.returncode != 0:
+        failures.append(f"remove remote test directory (exit {remove_result.returncode})")
+
     for port in (config.port, choose_gadget_port(config.port)):
         adb(serial, "forward", "--remove", f"tcp:{port}", check=False)
+
+    for remote_process in remote_processes:
+        result = root_shell(
+            serial,
+            f"pgrep -f '^{remote_process}([[:space:]]|$)'",
+            check=False,
+        )
+        if result.returncode == 0:
+            failures.append(f"process remains: {Path(remote_process).name}")
+        elif result.returncode != 1:
+            failures.append(f"verify {Path(remote_process).name} (exit {result.returncode})")
+
+    directory_result = root_shell(serial, f"test ! -e {REMOTE_DIR}", check=False)
+    if directory_result.returncode != 0:
+        failures.append("remote test directory remains")
+
+    forward_result = adb(serial, "forward", "--list", check=False)
+    if forward_result.returncode != 0:
+        failures.append(f"list adb forwards (exit {forward_result.returncode})")
+    else:
+        for port in (config.port, choose_gadget_port(config.port)):
+            if f"tcp:{port}" in forward_result.stdout:
+                failures.append(f"adb forward remains: tcp:{port}")
+
+    if failures:
+        raise SmokeFailure("Android smoke cleanup failed: " + "; ".join(failures))
 
 
 def run_android_smoke(config: AndroidSmokeConfig, script_path: Path) -> dict[str, object]:
@@ -675,6 +714,7 @@ def run_android_smoke(config: AndroidSmokeConfig, script_path: Path) -> dict[str
     if "package:" not in package_result.stdout:
         raise SmokeFailure(f"Android package is not installed: {config.package}")
 
+    primary_error: Exception | None = None
     try:
         remote_server, remote_gadget = _prepare_remote_files(config, serial)
         abi, api_level = _read_android_platform(serial)
@@ -694,7 +734,7 @@ def run_android_smoke(config: AndroidSmokeConfig, script_path: Path) -> dict[str
         _configure_forward(serial, config.port, server_endpoint.socket)
         run_command(
             server_start_command(serial, remote_server, server_endpoint),
-            redact=(server_endpoint.token,),
+            redact=(serial, server_endpoint.token),
         )
         server_device, processes = _wait_for_remote_device(
             manager,
@@ -722,8 +762,18 @@ def run_android_smoke(config: AndroidSmokeConfig, script_path: Path) -> dict[str
         )
         report["status"] = "passed"
         return report
+    except Exception as error:
+        primary_error = error
+        raise
     finally:
-        _cleanup(config, serial)
+        try:
+            _cleanup(config, serial)
+        except SmokeFailure as cleanup_error:
+            if primary_error is not None:
+                raise SmokeFailure(
+                    f"{primary_error}; cleanup also failed: {cleanup_error}"
+                ) from primary_error
+            raise
 
 
 def _write_report(path: Path, payload: dict[str, object]) -> None:

--- a/scripts/android_smoke.py
+++ b/scripts/android_smoke.py
@@ -6,6 +6,7 @@ import importlib
 import json
 import os
 import re
+import secrets
 import subprocess
 import sys
 import tempfile
@@ -27,7 +28,29 @@ REMOTE_DIR = "/data/local/tmp/phantom-frida-test"
 JAVA_BRIDGE_DIR = REPOSITORY_ROOT / "node_modules" / "frida-java-bridge"
 PACKAGE_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+$")
 SCRIPT_TIMEOUT_SECONDS = 45
+MEMORY_SCAN_MARKERS = (
+    "frida:rpc",
+    "FridaScriptEngine",
+    "GLib-GIO",
+    "GDBusProxy",
+    "GumScript",
+    "Frida/",
+    "frida-agent",
+    "frida-gadget",
+    "frida-eternal-agent",
+    "frida-generate-certificate",
+    "frida-main-loop",
+    "gum-js-loop",
+    "pool-frida",
+    "pool-spawner",
+)
 GADGET_PROBE_SOURCE = """'use strict';
+
+rpc.exports = {
+  add(left, right) {
+    return left + right;
+  }
+};
 
 send({ type: 'phantom-frida-gadget-result' });
 """
@@ -47,13 +70,45 @@ class AndroidSmokeConfig:
     ndk: Path
 
 
+@dataclass(frozen=True)
+class RemoteEndpoint:
+    socket: str
+    origin: str
+    token: str
+
+
+def create_remote_endpoint(name: str, role: str) -> RemoteEndpoint:
+    nonce = secrets.token_hex(8)
+    return RemoteEndpoint(
+        socket=f"{name}-{role}-{nonce}",
+        origin=f"https://{nonce}.invalid",
+        token=secrets.token_urlsafe(24),
+    )
+
+
 def choose_gadget_port(server_port: int) -> int:
     candidate = server_port + 1
     return candidate if candidate <= 65535 and candidate != 27042 else 27043
 
 
 def assert_clean_proc_text(label: str, text: str) -> None:
-    forbidden = ("frida-zymbiote", "frida-server", "frida-helper")
+    forbidden: tuple[str, ...] = (
+        "frida-zymbiote",
+        "frida-server",
+        "frida-helper",
+        "frida-gadget",
+        "frida-eternal-agent",
+        "frida-generate-certificate",
+        "frida-main-loop",
+    )
+    if label == "threads":
+        forbidden += (
+            "gum-js-loop",
+            "gmain",
+            "gdbus",
+            "pool-frida",
+            "pool-spawner",
+        )
     lowered = text.lower()
     matches = [marker for marker in forbidden if marker in lowered]
     if matches:
@@ -71,7 +126,7 @@ def require_single_device(adb_output: str) -> str:
     return devices[0]
 
 
-def server_start_command(serial: str, remote_server: str, port: int) -> list[str]:
+def server_start_command(serial: str, remote_server: str, endpoint: RemoteEndpoint) -> list[str]:
     remote_log = f"{REMOTE_DIR}/server.log"
     return [
         "adb",
@@ -80,7 +135,11 @@ def server_start_command(serial: str, remote_server: str, port: int) -> list[str
         "shell",
         "su",
         "-c",
-        (f"{remote_server} -l 0.0.0.0:{port} -D </dev/null >{remote_log} 2>&1"),
+        (
+            f"{remote_server} -l unix:{endpoint.socket} "
+            f"--origin {endpoint.origin} --token {endpoint.token} "
+            f"-D </dev/null >{remote_log} 2>&1"
+        ),
     ]
 
 
@@ -127,16 +186,29 @@ def validate_config(
 
 
 def run_command(
-    command: Sequence[str | os.PathLike[str]], *, check: bool = True
+    command: Sequence[str | os.PathLike[str]],
+    *,
+    check: bool = True,
+    redact: Sequence[str] = (),
 ) -> subprocess.CompletedProcess[str]:
     argv = [os.fspath(part) for part in command]
-    print(f"+ {subprocess.list2cmdline(argv)}", flush=True)
+    displayed_argv = []
+    for part in argv:
+        displayed = part
+        for secret in redact:
+            if secret:
+                displayed = displayed.replace(secret, "<redacted>")
+        displayed_argv.append(displayed)
+    print(f"+ {subprocess.list2cmdline(displayed_argv)}", flush=True)
     try:
         result = subprocess.run(argv, capture_output=True, text=True)
     except OSError as error:
         raise SmokeFailure(f"Unable to run {argv[0]}: {error}") from error
     if check and result.returncode != 0:
         details = (result.stderr or result.stdout or "").strip()
+        for secret in redact:
+            if secret:
+                details = details.replace(secret, "<redacted>")
         suffix = f": {details}" if details else ""
         raise SmokeFailure(f"Command failed with exit code {result.returncode}: {argv[0]}{suffix}")
     return result
@@ -206,13 +278,13 @@ def _prepare_remote_files(config: AndroidSmokeConfig, serial: str) -> tuple[str,
     return remote_server, remote_gadget
 
 
-def _configure_forward(serial: str, port: int) -> None:
+def _configure_forward(serial: str, port: int, socket_name: str) -> None:
     adb(serial, "forward", "--remove", f"tcp:{port}", check=False)
-    adb(serial, "forward", f"tcp:{port}", f"tcp:{port}")
+    adb(serial, "forward", f"tcp:{port}", f"localabstract:{socket_name}")
 
 
 def _wait_for_remote_device(
-    manager: Any, address: str, *, timeout: float = 20
+    manager: Any, address: str, endpoint: RemoteEndpoint, *, timeout: float = 20
 ) -> tuple[Any, list[Any]]:
     deadline = time.monotonic() + timeout
     last_error: Exception | None = None
@@ -220,7 +292,11 @@ def _wait_for_remote_device(
     while time.monotonic() < deadline:
         try:
             if device is None:
-                device = manager.add_remote_device(address)
+                device = manager.add_remote_device(
+                    address,
+                    origin=endpoint.origin,
+                    token=endpoint.token,
+                )
             return device, list(device.enumerate_processes())
         except Exception as error:  # external Frida exceptions vary by version
             last_error = error
@@ -229,7 +305,11 @@ def _wait_for_remote_device(
 
 
 def _run_script_acceptance(
-    device: Any, serial: str, package: str, agent_source: str
+    device: Any,
+    serial: str,
+    package: str,
+    agent_source: str,
+    memory_scanner: str,
 ) -> dict[str, object]:
     pid: int | None = None
     session: Any = None
@@ -256,6 +336,8 @@ def _run_script_acceptance(
         script = session.create_script(agent_source)
         script.on("message", on_message)
         script.load()
+        if script.exports_sync.add(20, 22) != 42:
+            raise SmokeFailure("Stock Frida RPC returned an unexpected server result")
         device.resume(pid)
 
         if not completed.wait(SCRIPT_TIMEOUT_SECONDS):
@@ -273,11 +355,17 @@ def _run_script_acceptance(
         if payload.get("javaAvailable") is not True:
             raise SmokeFailure("Java bridge is unavailable in the selected application")
 
-        _scan_process_procfs(serial, pid)
+        memory_report = _scan_process_procfs(
+            serial,
+            pid,
+            memory_scanner,
+            "memfd:jit-code-cache",
+        )
         return {
             "pid": pid,
             "java_available": True,
             "script_failures": [],
+            "memory": memory_report,
         }
     except SmokeFailure:
         raise
@@ -296,7 +384,37 @@ def _run_script_acceptance(
                 pass
 
 
-def _scan_process_procfs(serial: str, pid: int) -> None:
+def _parse_memory_scan(label: str, output: str) -> dict[str, int]:
+    values: dict[str, int] = {}
+    counts: dict[str, int] = {}
+    for line in output.splitlines():
+        if match := re.fullmatch(r"(ranges|executable)=(\d+)", line):
+            values[match.group(1)] = int(match.group(2))
+        elif match := re.fullmatch(r"marker=(.+) count=(\d+)", line):
+            counts[match.group(1)] = int(match.group(2))
+
+    if values.get("ranges", 0) == 0:
+        raise SmokeFailure(f"{label} memory scan found no matching memory ranges")
+    missing = [marker for marker in MEMORY_SCAN_MARKERS if marker not in counts]
+    if missing:
+        raise SmokeFailure(f"{label} memory scan omitted marker(s): {', '.join(missing)}")
+    detected = [
+        f"{marker}={counts[marker]}" for marker in MEMORY_SCAN_MARKERS if counts[marker] != 0
+    ]
+    if detected:
+        raise SmokeFailure(f"{label} memory scan found runtime signature(s): {', '.join(detected)}")
+    return {
+        "ranges": values["ranges"],
+        "executable": values.get("executable", 0),
+    }
+
+
+def _scan_process_procfs(
+    serial: str,
+    pid: int,
+    memory_scanner: str,
+    mapping_needle: str,
+) -> dict[str, int]:
     commands = {
         "unix": "cat /proc/net/unix",
         "maps": f"cat /proc/{pid}/maps",
@@ -306,6 +424,12 @@ def _scan_process_procfs(serial: str, pid: int) -> None:
     for label, command in commands.items():
         result = root_shell(serial, command)
         assert_clean_proc_text(label, result.stdout)
+    marker_arguments = " ".join(MEMORY_SCAN_MARKERS)
+    result = root_shell(
+        serial,
+        f"{memory_scanner} {pid} {mapping_needle} {marker_arguments}",
+    )
+    return _parse_memory_scan(mapping_needle, result.stdout)
 
 
 def _run_gadget_script_acceptance(device: Any, pid: int) -> None:
@@ -332,6 +456,8 @@ def _run_gadget_script_acceptance(device: Any, pid: int) -> None:
         script = session.create_script(GADGET_PROBE_SOURCE)
         script.on("message", on_message)
         script.load()
+        if "error" not in outcome and script.exports_sync.add(20, 22) != 42:
+            raise SmokeFailure("Stock Frida RPC returned an unexpected Gadget result")
         if not completed.wait(SCRIPT_TIMEOUT_SECONDS):
             raise SmokeFailure(
                 f"Frida Gadget script timed out after {SCRIPT_TIMEOUT_SECONDS} seconds"
@@ -364,9 +490,7 @@ def _find_ndk_clang(ndk: Path) -> Path:
     return candidates[0]
 
 
-def _compile_gadget_loader(
-    config: AndroidSmokeConfig, abi: str, api_level: int, output: Path
-) -> None:
+def _android_clang_target(abi: str, api_level: int) -> str:
     target_by_abi = {
         "arm64-v8a": "aarch64-linux-android",
         "armeabi-v7a": "armv7a-linux-androideabi",
@@ -375,14 +499,20 @@ def _compile_gadget_loader(
     }
     target = target_by_abi.get(abi)
     if target is None:
-        raise SmokeFailure(f"Unsupported Android ABI for Gadget loader: {abi}")
+        raise SmokeFailure(f"Unsupported Android ABI: {abi}")
+    return f"{target}{max(api_level, 21)}"
+
+
+def _compile_gadget_loader(
+    config: AndroidSmokeConfig, abi: str, api_level: int, output: Path
+) -> None:
     source = REPOSITORY_ROOT / "tests" / "android" / "gadget-loader.c"
     if not source.is_file():
         raise SmokeFailure(f"Gadget loader source is missing: {source}")
     run_command(
         [
             _find_ndk_clang(config.ndk),
-            f"--target={target}{max(api_level, 21)}",
+            f"--target={_android_clang_target(abi, api_level)}",
             "-fPIE",
             "-pie",
             source,
@@ -393,21 +523,73 @@ def _compile_gadget_loader(
     )
 
 
-def _exercise_gadget(
-    config: AndroidSmokeConfig,
-    serial: str,
-    manager: Any,
-    remote_gadget: str,
-) -> dict[str, object]:
-    gadget_port = choose_gadget_port(config.port)
-    _configure_forward(serial, gadget_port)
+def _compile_proc_memory_scanner(
+    config: AndroidSmokeConfig, abi: str, api_level: int, output: Path
+) -> None:
+    source = REPOSITORY_ROOT / "tests" / "android" / "proc-memory-scanner.c"
+    if not source.is_file():
+        raise SmokeFailure(f"Process memory scanner source is missing: {source}")
+    run_command(
+        [
+            _find_ndk_clang(config.ndk),
+            f"--target={_android_clang_target(abi, api_level)}",
+            "-fPIE",
+            "-pie",
+            source,
+            "-o",
+            output,
+        ]
+    )
+
+
+def _read_android_platform(serial: str) -> tuple[str, int]:
     abi = adb(serial, "shell", "getprop", "ro.product.cpu.abi").stdout.strip()
     api_text = adb(serial, "shell", "getprop", "ro.build.version.sdk").stdout.strip()
     try:
         api_level = int(api_text)
     except ValueError as error:
         raise SmokeFailure(f"Invalid Android API level reported by device: {api_text!r}") from error
+    _android_clang_target(abi, api_level)
+    return abi, api_level
 
+
+def _prepare_proc_memory_scanner(
+    config: AndroidSmokeConfig,
+    serial: str,
+    abi: str,
+    api_level: int,
+) -> str:
+    remote_scanner = f"{REMOTE_DIR}/proc-memory-scanner"
+    with tempfile.TemporaryDirectory(prefix="phantom-frida-scanner-") as temporary:
+        scanner = Path(temporary) / "proc-memory-scanner"
+        _compile_proc_memory_scanner(config, abi, api_level, scanner)
+        adb(serial, "push", scanner, remote_scanner)
+    adb(serial, "shell", "chmod", "755", remote_scanner)
+    return remote_scanner
+
+
+def _gadget_interaction(endpoint: RemoteEndpoint) -> dict[str, str]:
+    return {
+        "type": "listen",
+        "address": f"unix:{endpoint.socket}",
+        "origin": endpoint.origin,
+        "token": endpoint.token,
+        "on_load": "resume",
+    }
+
+
+def _exercise_gadget(
+    config: AndroidSmokeConfig,
+    serial: str,
+    manager: Any,
+    remote_gadget: str,
+    memory_scanner: str,
+    abi: str,
+    api_level: int,
+) -> dict[str, object]:
+    gadget_port = choose_gadget_port(config.port)
+    endpoint = create_remote_endpoint(config.name, "gadget")
+    _configure_forward(serial, gadget_port, endpoint.socket)
     remote_loader = f"{REMOTE_DIR}/gadget-loader"
     remote_config = f"{REMOTE_DIR}/lib{config.name}-gadget.config.so"
     remote_log = f"{REMOTE_DIR}/gadget-loader.log"
@@ -418,14 +600,7 @@ def _exercise_gadget(
         _compile_gadget_loader(config, abi, api_level, loader)
         gadget_config.write_text(
             json.dumps(
-                {
-                    "interaction": {
-                        "type": "listen",
-                        "address": "0.0.0.0",
-                        "port": gadget_port,
-                        "on_load": "resume",
-                    }
-                },
+                {"interaction": _gadget_interaction(endpoint)},
                 indent=2,
                 sort_keys=True,
             )
@@ -440,7 +615,11 @@ def _exercise_gadget(
         f"{remote_loader} {remote_gadget} >{remote_log} 2>&1 &",
     )
 
-    gadget_device, processes = _wait_for_remote_device(manager, f"127.0.0.1:{gadget_port}")
+    gadget_device, processes = _wait_for_remote_device(
+        manager,
+        f"127.0.0.1:{gadget_port}",
+        endpoint,
+    )
     if not processes:
         raise SmokeFailure("Stock Frida enumerated no process through Gadget")
     gadget_pid = getattr(processes[0], "pid", None)
@@ -448,12 +627,19 @@ def _exercise_gadget(
         raise SmokeFailure("Stock Frida returned a Gadget process without an integer pid")
     _run_gadget_script_acceptance(gadget_device, gadget_pid)
     assert_clean_proc_text("gadget unix", root_shell(serial, "cat /proc/net/unix").stdout)
+    memory_report = _scan_process_procfs(
+        serial,
+        gadget_pid,
+        memory_scanner,
+        f"lib{config.name}-gadget.so",
+    )
     return {
         "abi": abi,
         "api_level": api_level,
         "port": gadget_port,
         "process_count": len(processes),
         "script_loaded": True,
+        "memory": memory_report,
     }
 
 
@@ -462,6 +648,7 @@ def _cleanup(config: AndroidSmokeConfig, serial: str) -> None:
     remote_loader = f"{REMOTE_DIR}/gadget-loader"
     root_shell(serial, f"pkill -9 -f {remote_server} || true", check=False)
     root_shell(serial, f"pkill -9 -f {remote_loader} || true", check=False)
+    root_shell(serial, f"rm -rf -- {REMOTE_DIR}", check=False)
     for port in (config.port, choose_gadget_port(config.port)):
         adb(serial, "forward", "--remove", f"tcp:{port}", check=False)
 
@@ -477,24 +664,51 @@ def run_android_smoke(config: AndroidSmokeConfig, script_path: Path) -> dict[str
     if "package:" not in package_result.stdout:
         raise SmokeFailure(f"Android package is not installed: {config.package}")
 
-    remote_server, remote_gadget = _prepare_remote_files(config, serial)
-    manager = frida_module.get_device_manager()
-    report: dict[str, object] = {
-        "frida_version": str(frida_module.__version__),
-        "package": config.package,
-        "server_port": config.port,
-    }
     try:
-        _configure_forward(serial, config.port)
-        run_command(server_start_command(serial, remote_server, config.port))
-        server_device, processes = _wait_for_remote_device(manager, f"127.0.0.1:{config.port}")
+        remote_server, remote_gadget = _prepare_remote_files(config, serial)
+        abi, api_level = _read_android_platform(serial)
+        memory_scanner = _prepare_proc_memory_scanner(
+            config,
+            serial,
+            abi,
+            api_level,
+        )
+        server_endpoint = create_remote_endpoint(config.name, "server")
+        manager = frida_module.get_device_manager()
+        report: dict[str, object] = {
+            "frida_version": str(frida_module.__version__),
+            "package": config.package,
+            "server_port": config.port,
+        }
+        _configure_forward(serial, config.port, server_endpoint.socket)
+        run_command(
+            server_start_command(serial, remote_server, server_endpoint),
+            redact=(server_endpoint.token,),
+        )
+        server_device, processes = _wait_for_remote_device(
+            manager,
+            f"127.0.0.1:{config.port}",
+            server_endpoint,
+        )
         if not processes:
             raise SmokeFailure("Stock Frida enumerated no processes through the server")
         report["server_process_count"] = len(processes)
         report["server"] = _run_script_acceptance(
-            server_device, serial, config.package, agent_source
+            server_device,
+            serial,
+            config.package,
+            agent_source,
+            memory_scanner,
         )
-        report["gadget"] = _exercise_gadget(config, serial, manager, remote_gadget)
+        report["gadget"] = _exercise_gadget(
+            config,
+            serial,
+            manager,
+            remote_gadget,
+            memory_scanner,
+            abi,
+            api_level,
+        )
         report["status"] = "passed"
         return report
     finally:

--- a/scripts/android_smoke.py
+++ b/scripts/android_smoke.py
@@ -656,19 +656,46 @@ def _exercise_gadget(
 
 
 def _cleanup(config: AndroidSmokeConfig, serial: str) -> None:
-    remote_server = f"{REMOTE_DIR}/{config.name}-server"
-    remote_loader = f"{REMOTE_DIR}/gadget-loader"
-    remote_processes = (remote_server, remote_loader)
+    processes = (
+        (f"{config.name}-server", f"{config.name}-server"[:15]),
+        ("gadget-loader", "gadget-loader"),
+    )
     failures: list[str] = []
+    signaled = False
 
-    for remote_process in remote_processes:
+    for label, process_comm in processes:
         result = root_shell(
             serial,
-            f"pkill -9 -f '^{remote_process}([[:space:]]|$)'",
+            f"pkill -TERM -x {process_comm}",
             check=False,
         )
+        signaled = signaled or result.returncode == 0
         if result.returncode not in (0, 1):
-            failures.append(f"stop {Path(remote_process).name} (exit {result.returncode})")
+            failures.append(f"stop {label} (exit {result.returncode})")
+
+    if signaled:
+        time.sleep(0.5)
+
+    forced: list[tuple[str, str]] = []
+    for label, process_comm in processes:
+        result = root_shell(serial, f"pgrep -x {process_comm}", check=False)
+        if result.returncode == 0:
+            forced.append((label, process_comm))
+            kill_result = root_shell(serial, f"pkill -KILL -x {process_comm}", check=False)
+            if kill_result.returncode not in (0, 1):
+                failures.append(f"force-stop {label} (exit {kill_result.returncode})")
+        elif result.returncode != 1:
+            failures.append(f"verify {label} (exit {result.returncode})")
+
+    if forced:
+        failures.append("processes did not stop gracefully: " + ", ".join(x[0] for x in forced))
+        time.sleep(0.2)
+        for label, process_comm in forced:
+            result = root_shell(serial, f"pgrep -x {process_comm}", check=False)
+            if result.returncode == 0:
+                failures.append(f"process remains: {label}")
+            elif result.returncode != 1:
+                failures.append(f"verify {label} after SIGKILL (exit {result.returncode})")
 
     remove_result = root_shell(serial, f"rm -rf -- {REMOTE_DIR}", check=False)
     if remove_result.returncode != 0:
@@ -677,20 +704,22 @@ def _cleanup(config: AndroidSmokeConfig, serial: str) -> None:
     for port in (config.port, choose_gadget_port(config.port)):
         adb(serial, "forward", "--remove", f"tcp:{port}", check=False)
 
-    for remote_process in remote_processes:
-        result = root_shell(
-            serial,
-            f"pgrep -f '^{remote_process}([[:space:]]|$)'",
-            check=False,
-        )
-        if result.returncode == 0:
-            failures.append(f"process remains: {Path(remote_process).name}")
-        elif result.returncode != 1:
-            failures.append(f"verify {Path(remote_process).name} (exit {result.returncode})")
-
     directory_result = root_shell(serial, f"test ! -e {REMOTE_DIR}", check=False)
     if directory_result.returncode != 0:
         failures.append("remote test directory remains")
+
+    socket_result = root_shell(serial, "cat /proc/net/unix", check=False)
+    if socket_result.returncode != 0:
+        failures.append(f"list unix sockets (exit {socket_result.returncode})")
+    else:
+        socket_markers = (
+            f"@{config.name}-server-",
+            f"@{config.name}-gadget-",
+            f"@/{config.name}-zymbiote-",
+        )
+        for marker in socket_markers:
+            if marker in socket_result.stdout:
+                failures.append(f"unix socket remains: {marker}")
 
     forward_result = adb(serial, "forward", "--list", check=False)
     if forward_result.returncode != 0:

--- a/scripts/android_smoke.py
+++ b/scripts/android_smoke.py
@@ -655,47 +655,83 @@ def _exercise_gadget(
     }
 
 
+def _parse_remote_processes(output: str, remote_executables: Sequence[str]) -> dict[str, list[int]]:
+    matches: dict[str, list[int]] = {path: [] for path in remote_executables}
+    for line in output.splitlines():
+        match = re.search(r"/proc/(\d+)/exe -> (.+)$", line)
+        if match is None:
+            continue
+        target = match.group(2).removesuffix(" (deleted)")
+        if target in matches:
+            matches[target].append(int(match.group(1)))
+    return matches
+
+
+def _remote_signal_command(remote_executable: str, pid: int, signal: str) -> str:
+    body = (
+        f"target=$(readlink /proc/{pid}/exe 2>/dev/null) || exit 0; "
+        f'case "$target" in "{remote_executable}"|"{remote_executable} (deleted)") '
+        f"kill -{signal} {pid} || exit 1 ;; esac; exit 0"
+    )
+    return f"'{body}'"
+
+
 def _cleanup(config: AndroidSmokeConfig, serial: str) -> None:
     processes = (
-        (f"{config.name}-server", f"{config.name}-server"[:15]),
-        ("gadget-loader", "gadget-loader"),
+        (f"{config.name}-server", f"{REMOTE_DIR}/{config.name}-server"),
+        ("gadget-loader", f"{REMOTE_DIR}/gadget-loader"),
     )
     failures: list[str] = []
-    signaled = False
+    remote_executables = tuple(path for _label, path in processes)
 
-    for label, process_comm in processes:
+    def snapshot(stage: str) -> dict[str, list[int]] | None:
         result = root_shell(
             serial,
-            f"pkill -TERM -x {process_comm}",
+            "'ls -l /proc/[0-9]*/exe 2>/dev/null; exit 0'",
             check=False,
         )
-        signaled = signaled or result.returncode == 0
-        if result.returncode not in (0, 1):
-            failures.append(f"stop {label} (exit {result.returncode})")
+        if result.returncode != 0:
+            failures.append(f"{stage} (exit {result.returncode})")
+            return None
+        return _parse_remote_processes(result.stdout, remote_executables)
 
-    if signaled:
-        time.sleep(0.5)
+    initial = snapshot("list Android smoke processes")
+    if initial is not None:
+        for label, remote_executable in processes:
+            for pid in initial[remote_executable]:
+                result = root_shell(
+                    serial,
+                    _remote_signal_command(remote_executable, pid, "TERM"),
+                    check=False,
+                )
+                if result.returncode != 0:
+                    failures.append(f"stop {label} (exit {result.returncode})")
+        if any(initial.values()):
+            time.sleep(0.5)
 
-    forced: list[tuple[str, str]] = []
-    for label, process_comm in processes:
-        result = root_shell(serial, f"pgrep -x {process_comm}", check=False)
-        if result.returncode == 0:
-            forced.append((label, process_comm))
-            kill_result = root_shell(serial, f"pkill -KILL -x {process_comm}", check=False)
-            if kill_result.returncode not in (0, 1):
-                failures.append(f"force-stop {label} (exit {kill_result.returncode})")
-        elif result.returncode != 1:
-            failures.append(f"verify {label} (exit {result.returncode})")
+    remaining = snapshot("verify Android smoke processes")
+    forced_labels: list[str] = []
+    if remaining is not None:
+        for label, remote_executable in processes:
+            for pid in remaining[remote_executable]:
+                if label not in forced_labels:
+                    forced_labels.append(label)
+                result = root_shell(
+                    serial,
+                    _remote_signal_command(remote_executable, pid, "KILL"),
+                    check=False,
+                )
+                if result.returncode != 0:
+                    failures.append(f"force-stop {label} (exit {result.returncode})")
 
-    if forced:
-        failures.append("processes did not stop gracefully: " + ", ".join(x[0] for x in forced))
+    if forced_labels:
+        failures.append("processes did not stop gracefully: " + ", ".join(forced_labels))
         time.sleep(0.2)
-        for label, process_comm in forced:
-            result = root_shell(serial, f"pgrep -x {process_comm}", check=False)
-            if result.returncode == 0:
-                failures.append(f"process remains: {label}")
-            elif result.returncode != 1:
-                failures.append(f"verify {label} after SIGKILL (exit {result.returncode})")
+        final = snapshot("verify Android smoke processes after SIGKILL")
+        if final is not None:
+            for label, remote_executable in processes:
+                if final[remote_executable]:
+                    failures.append(f"process remains: {label}")
 
     remove_result = root_shell(serial, f"rm -rf -- {REMOTE_DIR}", check=False)
     if remove_result.returncode != 0:

--- a/scripts/android_smoke.py
+++ b/scripts/android_smoke.py
@@ -109,10 +109,14 @@ def assert_clean_proc_text(label: str, text: str) -> None:
             "pool-frida",
             "pool-spawner",
         )
+    elif label == "fds":
+        forbidden += ("linjector",)
     lowered = text.lower()
     matches = [marker for marker in forbidden if marker in lowered]
     if matches:
         raise SmokeFailure(f"{label} contains forbidden marker(s): {', '.join(matches)}")
+    if label == "status" and re.search(r"^TracerPid:\s*[1-9]\d*$", text, re.MULTILINE):
+        raise SmokeFailure("status contains an active TracerPid")
 
 
 def require_single_device(adb_output: str) -> str:
@@ -426,6 +430,7 @@ def _scan_process_procfs(
         "unix": "cat /proc/net/unix",
         "maps": f"cat /proc/{pid}/maps",
         "fds": f"ls -l /proc/{pid}/fd",
+        "status": f"cat /proc/{pid}/status",
         "threads": f"cat /proc/{pid}/task/*/comm",
     }
     for label, command in commands.items():

--- a/scripts/android_smoke.py
+++ b/scripts/android_smoke.py
@@ -126,6 +126,13 @@ def require_single_device(adb_output: str) -> str:
     return devices[0]
 
 
+def assert_interactive_device(power_state: str, window_policy: str) -> None:
+    if "mWakefulness=Awake" not in power_state:
+        raise SmokeFailure("Android device must be awake before spawn acceptance")
+    if "mInputRestricted=true" in window_policy:
+        raise SmokeFailure("Android device must be unlocked before spawn acceptance")
+
+
 def server_start_command(serial: str, remote_server: str, endpoint: RemoteEndpoint) -> list[str]:
     remote_log = f"{REMOTE_DIR}/server.log"
     return [
@@ -660,6 +667,10 @@ def run_android_smoke(config: AndroidSmokeConfig, script_path: Path) -> dict[str
     root_result = root_shell(serial, "id")
     if "uid=0" not in root_result.stdout:
         raise SmokeFailure(f"adb device does not provide root through su: {root_result.stdout}")
+    assert_interactive_device(
+        adb(serial, "shell", "dumpsys", "power").stdout,
+        adb(serial, "shell", "dumpsys", "window", "policy").stdout,
+    )
     package_result = adb(serial, "shell", "pm", "path", config.package)
     if "package:" not in package_result.stdout:
         raise SmokeFailure(f"Android package is not installed: {config.package}")

--- a/test_comprehensive.js
+++ b/test_comprehensive.js
@@ -2,6 +2,12 @@
 
 import Java from 'frida-java-bridge';
 
+rpc.exports = {
+    add(left, right) {
+        return left + right;
+    }
+};
+
 // Structured acceptance test: native stealth markers, Java bridge, and a live hook.
 setTimeout(function () {
     var failures = [];

--- a/tests/android/proc-memory-scanner.c
+++ b/tests/android/proc-memory-scanner.c
@@ -1,0 +1,146 @@
+#define _FILE_OFFSET_BITS 64
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define CHUNK_SIZE (64 * 1024)
+
+static int scan_range(int fd, unsigned long long start, unsigned long long end,
+                      char **markers, int marker_count,
+                      unsigned long long *counts) {
+  size_t longest = 1;
+  for (int i = 0; i < marker_count; i++) {
+    size_t length = strlen(markers[i]);
+    if (length > longest)
+      longest = length;
+  }
+
+  unsigned char *buffer = malloc(CHUNK_SIZE + longest);
+  if (buffer == NULL)
+    return -1;
+
+  size_t carried = 0;
+  unsigned long long cursor = start;
+  while (cursor < end) {
+    size_t wanted = CHUNK_SIZE;
+    if (end - cursor < wanted)
+      wanted = (size_t)(end - cursor);
+
+    ssize_t received;
+    do {
+      received = pread(fd, buffer + carried, wanted, (off_t)cursor);
+    } while (received < 0 && errno == EINTR);
+    if (received <= 0) {
+      free(buffer);
+      return -1;
+    }
+
+    size_t available = carried + (size_t)received;
+    for (int marker_index = 0; marker_index < marker_count; marker_index++) {
+      size_t marker_length = strlen(markers[marker_index]);
+      for (size_t offset = 0; offset + marker_length <= available; offset++) {
+        if (offset + marker_length <= carried)
+          continue;
+        if (memcmp(buffer + offset, markers[marker_index], marker_length) == 0)
+          counts[marker_index]++;
+      }
+    }
+
+    size_t overlap = longest - 1;
+    carried = available < overlap ? available : overlap;
+    memmove(buffer, buffer + available - carried, carried);
+    cursor += (unsigned long long)received;
+  }
+
+  free(buffer);
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 4) {
+    fprintf(stderr, "usage: proc-memory-scanner PID MAPPING_NEEDLE MARKER...\n");
+    return 2;
+  }
+
+  char *pid_end = NULL;
+  long pid = strtol(argv[1], &pid_end, 10);
+  if (pid <= 0 || pid_end == NULL || *pid_end != '\0') {
+    fprintf(stderr, "invalid pid: %s\n", argv[1]);
+    return 2;
+  }
+
+  char maps_path[64];
+  char mem_path[64];
+  snprintf(maps_path, sizeof(maps_path), "/proc/%ld/maps", pid);
+  snprintf(mem_path, sizeof(mem_path), "/proc/%ld/mem", pid);
+
+  FILE *maps = fopen(maps_path, "r");
+  if (maps == NULL) {
+    perror("open maps");
+    return 1;
+  }
+  int mem = open(mem_path, O_RDONLY | O_CLOEXEC);
+  if (mem < 0) {
+    perror("open mem");
+    fclose(maps);
+    return 1;
+  }
+
+  int marker_count = argc - 3;
+  unsigned long long *counts = calloc((size_t)marker_count, sizeof(*counts));
+  if (counts == NULL) {
+    fprintf(stderr, "unable to allocate marker counters\n");
+    close(mem);
+    fclose(maps);
+    return 1;
+  }
+
+  unsigned long long ranges = 0;
+  unsigned long long executable = 0;
+  char *line = NULL;
+  size_t line_capacity = 0;
+  int status = 0;
+  while (getline(&line, &line_capacity, maps) >= 0) {
+    unsigned long long start;
+    unsigned long long end;
+    char permissions[5] = {0};
+    char path[4096] = {0};
+    int fields = sscanf(line, "%llx-%llx %4s %*s %*s %*s %4095[^\n]", &start,
+                        &end, permissions, path);
+    if (fields != 4 || permissions[0] != 'r' ||
+        strstr(path, argv[2]) == NULL)
+      continue;
+
+    ranges++;
+    if (permissions[2] == 'x')
+      executable++;
+    if (scan_range(mem, start, end, argv + 3, marker_count, counts) != 0) {
+      fprintf(stderr, "unable to scan %llx-%llx: %s\n", start, end,
+              strerror(errno));
+      status = 1;
+      break;
+    }
+  }
+
+  if (ferror(maps)) {
+    perror("read maps");
+    status = 1;
+  }
+  if (status == 0) {
+    printf("ranges=%llu\n", ranges);
+    printf("executable=%llu\n", executable);
+    for (int i = 0; i < marker_count; i++)
+      printf("marker=%s count=%llu\n", argv[i + 3], counts[i]);
+  }
+
+  free(line);
+  free(counts);
+  close(mem);
+  fclose(maps);
+  return status;
+}

--- a/tests/test_android_smoke.py
+++ b/tests/test_android_smoke.py
@@ -143,6 +143,7 @@ def test_interactive_device_preflight_accepts_unlocked_screen() -> None:
     [
         ("mWakefulness=Dozing\n", "mInputRestricted=false\n", "awake"),
         ("mWakefulness=Awake\n", "mInputRestricted=true\n", "unlocked"),
+        ("mWakefulness=Awake\n", "KeyguardServiceDelegate\n", "unlocked"),
     ],
 )
 def test_interactive_device_preflight_rejects_blocked_spawn_state(
@@ -500,16 +501,112 @@ def test_report_writer_omits_device_serial(tmp_path: Path) -> None:
     assert "device_serial" not in report
 
 
+def test_adb_redacts_serial_from_command_and_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    serial = "SECRET-SERIAL"
+
+    def fail_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            stdout="",
+            stderr=f"adb: device '{serial}' not found",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fail_run)
+
+    with pytest.raises(android_smoke.SmokeFailure) as failure:
+        android_smoke.adb(serial, "shell", "id")
+
+    rendered = capsys.readouterr().out + str(failure.value)
+    assert serial not in rendered
+    assert "<redacted>" in rendered
+
+
 def test_cleanup_removes_remote_test_directory(monkeypatch: pytest.MonkeyPatch) -> None:
     root_commands: list[str] = []
-    monkeypatch.setattr(
-        android_smoke,
-        "root_shell",
-        lambda _serial, command, **_kwargs: root_commands.append(command),
-    )
-    monkeypatch.setattr(android_smoke, "adb", lambda *_args, **_kwargs: None)
+    adb_commands: list[tuple[str, ...]] = []
+
+    def fake_root_shell(_serial: str, command: str, **_kwargs: object) -> SimpleNamespace:
+        root_commands.append(command)
+        return SimpleNamespace(
+            returncode=1 if command.startswith(("pkill", "pgrep")) else 0,
+            stdout="",
+            stderr="",
+        )
+
+    def fake_adb(_serial: str, *arguments: str, **_kwargs: object) -> SimpleNamespace:
+        adb_commands.append(arguments)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(android_smoke, "root_shell", fake_root_shell)
+    monkeypatch.setattr(android_smoke, "adb", fake_adb)
     config = SimpleNamespace(name="oemcodec", port=27142)
 
     android_smoke._cleanup(config, "SERIAL-1")
 
-    assert root_commands[-1] == "rm -rf -- /data/local/tmp/phantom-frida-test"
+    assert "rm -rf -- /data/local/tmp/phantom-frida-test" in root_commands
+    assert ("forward", "--list") in adb_commands
+
+
+def test_cleanup_attempts_every_step_and_reports_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_commands: list[str] = []
+    adb_commands: list[tuple[str, ...]] = []
+
+    def fake_root_shell(_serial: str, command: str, **_kwargs: object) -> SimpleNamespace:
+        root_commands.append(command)
+        if command.startswith("rm -rf"):
+            return SimpleNamespace(returncode=1, stdout="", stderr="permission denied")
+        return SimpleNamespace(
+            returncode=1 if command.startswith(("pkill", "pgrep")) else 0,
+            stdout="",
+            stderr="",
+        )
+
+    def fake_adb(_serial: str, *arguments: str, **_kwargs: object) -> SimpleNamespace:
+        adb_commands.append(arguments)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(android_smoke, "root_shell", fake_root_shell)
+    monkeypatch.setattr(android_smoke, "adb", fake_adb)
+    config = SimpleNamespace(name="oemcodec", port=27142)
+
+    with pytest.raises(android_smoke.SmokeFailure, match="remove remote test directory"):
+        android_smoke._cleanup(config, "SERIAL-1")
+
+    assert len([command for command in root_commands if command.startswith("pkill")]) == 2
+    assert len([command for command in root_commands if command.startswith("pgrep")]) == 2
+    assert ("forward", "--remove", "tcp:27142") in adb_commands
+    assert ("forward", "--remove", "tcp:27143") in adb_commands
+    assert ("forward", "--list") in adb_commands
+
+
+def test_cleanup_rejects_lingering_forward(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_root_shell(_serial: str, command: str, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            returncode=1 if command.startswith(("pkill", "pgrep")) else 0,
+            stdout="",
+            stderr="",
+        )
+
+    def fake_adb(_serial: str, *arguments: str, **_kwargs: object) -> SimpleNamespace:
+        stdout = (
+            "SERIAL-1 tcp:27142 localabstract:oemcodec-server\n"
+            if arguments
+            == (
+                "forward",
+                "--list",
+            )
+            else ""
+        )
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(android_smoke, "root_shell", fake_root_shell)
+    monkeypatch.setattr(android_smoke, "adb", fake_adb)
+    config = SimpleNamespace(name="oemcodec", port=27142)
+
+    with pytest.raises(android_smoke.SmokeFailure, match="forward remains"):
+        android_smoke._cleanup(config, "SERIAL-1")

--- a/tests/test_android_smoke.py
+++ b/tests/test_android_smoke.py
@@ -542,12 +542,24 @@ def test_adb_redacts_serial_from_command_and_failure(
 def test_cleanup_removes_remote_test_directory(monkeypatch: pytest.MonkeyPatch) -> None:
     root_commands: list[str] = []
     adb_commands: list[tuple[str, ...]] = []
+    snapshot_calls = 0
 
     def fake_root_shell(_serial: str, command: str, **_kwargs: object) -> SimpleNamespace:
+        nonlocal snapshot_calls
         root_commands.append(command)
+        stdout = ""
+        if "/proc/[0-9]*/exe" in command:
+            snapshot_calls += 1
+            if snapshot_calls == 1:
+                stdout = (
+                    "lrwxrwxrwx root /proc/101/exe -> "
+                    "/data/local/tmp/phantom-frida-test/oemcodec-server\n"
+                    "lrwxrwxrwx root /proc/102/exe -> "
+                    "/data/local/tmp/phantom-frida-test/gadget-loader\n"
+                )
         return SimpleNamespace(
             returncode=1 if command.startswith(("pkill", "pgrep")) else 0,
-            stdout="",
+            stdout=stdout,
             stderr="",
         )
 
@@ -557,12 +569,21 @@ def test_cleanup_removes_remote_test_directory(monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setattr(android_smoke, "root_shell", fake_root_shell)
     monkeypatch.setattr(android_smoke, "adb", fake_adb)
+    monkeypatch.setattr(android_smoke.time, "sleep", lambda _seconds: None)
     config = SimpleNamespace(name="oemcodec", port=27142)
 
     android_smoke._cleanup(config, "SERIAL-1")
 
-    assert "pkill -TERM -x oemcodec-server" in root_commands
-    assert "pkill -TERM -x gadget-loader" in root_commands
+    term_commands = [command for command in root_commands if "kill -TERM" in command]
+    assert len(term_commands) == 2
+    assert all("readlink /proc/" in command for command in term_commands)
+    assert any(
+        "/data/local/tmp/phantom-frida-test/oemcodec-server" in command for command in term_commands
+    )
+    assert any(
+        "/data/local/tmp/phantom-frida-test/gadget-loader" in command for command in term_commands
+    )
+    assert not any(command.startswith("pkill") for command in root_commands)
     assert "rm -rf -- /data/local/tmp/phantom-frida-test" in root_commands
     assert ("forward", "--list") in adb_commands
 
@@ -594,8 +615,8 @@ def test_cleanup_attempts_every_step_and_reports_failures(
     with pytest.raises(android_smoke.SmokeFailure, match="remove remote test directory"):
         android_smoke._cleanup(config, "SERIAL-1")
 
-    assert len([command for command in root_commands if command.startswith("pkill")]) == 2
-    assert len([command for command in root_commands if command.startswith("pgrep")]) == 2
+    assert len([command for command in root_commands if "/proc/[0-9]*/exe" in command]) == 2
+    assert not any(command.startswith(("pkill", "pgrep")) for command in root_commands)
     assert ("forward", "--remove", "tcp:27142") in adb_commands
     assert ("forward", "--remove", "tcp:27143") in adb_commands
     assert ("forward", "--list") in adb_commands
@@ -650,27 +671,25 @@ def test_cleanup_rejects_lingering_runtime_socket(monkeypatch: pytest.MonkeyPatc
         android_smoke._cleanup(config, "SERIAL-1")
 
 
-def test_cleanup_uses_kernel_comm_limit_for_long_server_name(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    root_commands: list[str] = []
+def test_remote_signal_is_scoped_to_exact_long_name_executable() -> None:
+    remote_executable = "/data/local/tmp/phantom-frida-test/abcdefghijklmnopqrst-server"
 
-    def fake_root_shell(_serial: str, command: str, **_kwargs: object) -> SimpleNamespace:
-        root_commands.append(command)
-        return SimpleNamespace(
-            returncode=1 if command.startswith(("pkill", "pgrep")) else 0,
-            stdout="",
-            stderr="",
-        )
+    command = android_smoke._remote_signal_command(remote_executable, 123, "TERM")
 
-    monkeypatch.setattr(android_smoke, "root_shell", fake_root_shell)
-    monkeypatch.setattr(
-        android_smoke,
-        "adb",
-        lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    assert "readlink /proc/123/exe" in command
+    assert remote_executable in command
+    assert "kill -TERM 123" in command
+    assert "pkill" not in command
+
+
+def test_parse_remote_processes_excludes_same_basename_outside_test_directory() -> None:
+    remote_executable = "/data/local/tmp/phantom-frida-test/oemcodec-server"
+    output = (
+        f"lrwxrwxrwx root /proc/101/exe -> {remote_executable}\n"
+        f"lrwxrwxrwx root /proc/102/exe -> {remote_executable} (deleted)\n"
+        "lrwxrwxrwx root /proc/103/exe -> /other/path/oemcodec-server\n"
     )
-    config = SimpleNamespace(name="abcdefghijklmnopqrst", port=27142)
 
-    android_smoke._cleanup(config, "SERIAL-1")
-
-    assert "pkill -TERM -x abcdefghijklmno" in root_commands
+    assert android_smoke._parse_remote_processes(output, (remote_executable,)) == {
+        remote_executable: [101, 102]
+    }

--- a/tests/test_android_smoke.py
+++ b/tests/test_android_smoke.py
@@ -1,10 +1,17 @@
 import json
+import subprocess
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
 
 from scripts import android_smoke
+
+
+def clean_memory_scan_output() -> str:
+    lines = ["ranges=7", "executable=3"]
+    lines.extend(f"marker={marker} count=0" for marker in android_smoke.MEMORY_SCAN_MARKERS)
+    return "\n".join(lines) + "\n"
 
 
 def test_proc_scan_rejects_zymbiote_socket() -> None:
@@ -18,22 +25,98 @@ def test_proc_scan_accepts_custom_runtime_names() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "frida-gadget",
+        "frida-eternal-agent",
+        "frida-generate-certificate",
+        "frida-main-loop",
+        "gum-js-loop",
+        "gmain",
+        "gdbus",
+        "pool-frida",
+        "pool-spawner",
+    ],
+)
+def test_proc_scan_rejects_modern_runtime_thread_markers(marker: str) -> None:
+    with pytest.raises(android_smoke.SmokeFailure, match=marker):
+        android_smoke.assert_clean_proc_text("threads", marker)
+
+
 def test_proc_scan_uses_portable_single_commands(monkeypatch: pytest.MonkeyPatch) -> None:
     commands: list[str] = []
 
     def fake_root_shell(_serial: str, command: str) -> SimpleNamespace:
         commands.append(command)
-        return SimpleNamespace(stdout="")
+        output = clean_memory_scan_output() if "proc-memory-scanner" in command else ""
+        return SimpleNamespace(stdout=output)
 
     monkeypatch.setattr(android_smoke, "root_shell", fake_root_shell)
 
-    android_smoke._scan_process_procfs("SERIAL-1", 123)
+    report = android_smoke._scan_process_procfs(
+        "SERIAL-1",
+        123,
+        "/data/local/tmp/phantom-frida-test/proc-memory-scanner",
+        "memfd:jit-code-cache",
+    )
 
-    assert commands == [
+    assert commands[:4] == [
         "cat /proc/net/unix",
         "cat /proc/123/maps",
         "ls -l /proc/123/fd",
         "cat /proc/123/task/*/comm",
+    ]
+    assert commands[4].startswith(
+        "/data/local/tmp/phantom-frida-test/proc-memory-scanner 123 memfd:jit-code-cache"
+    )
+    assert report == {"ranges": 7, "executable": 3}
+
+
+def test_memory_scan_rejects_runtime_signature() -> None:
+    output = clean_memory_scan_output().replace(
+        "marker=frida:rpc count=0",
+        "marker=frida:rpc count=2",
+    )
+
+    with pytest.raises(android_smoke.SmokeFailure, match="frida:rpc=2"):
+        android_smoke._parse_memory_scan("server agent", output)
+
+
+def test_memory_scan_requires_matching_memory_ranges() -> None:
+    output = clean_memory_scan_output().replace("ranges=7", "ranges=0")
+
+    with pytest.raises(android_smoke.SmokeFailure, match="no matching memory ranges"):
+        android_smoke._parse_memory_scan("server agent", output)
+
+
+def test_proc_memory_scanner_is_compiled_for_device_abi(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    clang = tmp_path / "ndk/toolchains/llvm/prebuilt/windows-x86_64/bin/clang.exe"
+    clang.parent.mkdir(parents=True)
+    clang.write_bytes(b"")
+    output = tmp_path / "proc-memory-scanner"
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        android_smoke,
+        "run_command",
+        lambda command, **_kwargs: commands.append([str(part) for part in command]),
+    )
+    config = SimpleNamespace(ndk=tmp_path / "ndk")
+
+    android_smoke._compile_proc_memory_scanner(config, "arm64-v8a", 34, output)
+
+    assert commands == [
+        [
+            str(clang),
+            "--target=aarch64-linux-android34",
+            "-fPIE",
+            "-pie",
+            str(android_smoke.REPOSITORY_ROOT / "tests/android/proc-memory-scanner.c"),
+            "-o",
+            str(output),
+        ]
     ]
 
 
@@ -61,9 +144,15 @@ def test_require_single_device_rejects_invalid_device_count(output: str, count: 
         android_smoke.require_single_device(output)
 
 
-def test_server_start_command_uses_fixed_adb_argument_vector() -> None:
+def test_server_start_command_uses_authenticated_abstract_socket() -> None:
+    endpoint = android_smoke.RemoteEndpoint(
+        socket="oemcodec-server-a1b2c3",
+        origin="https://a1b2c3.invalid",
+        token="secret-token",
+    )
+
     assert android_smoke.server_start_command(
-        "SERIAL-1", "/data/local/tmp/phantom-frida-test/oemcodec-server", 27142
+        "SERIAL-1", "/data/local/tmp/phantom-frida-test/oemcodec-server", endpoint
     ) == [
         "adb",
         "-s",
@@ -73,10 +162,65 @@ def test_server_start_command_uses_fixed_adb_argument_vector() -> None:
         "-c",
         (
             "/data/local/tmp/phantom-frida-test/oemcodec-server "
-            "-l 0.0.0.0:27142 -D </dev/null "
+            "-l unix:oemcodec-server-a1b2c3 "
+            "--origin https://a1b2c3.invalid --token secret-token -D </dev/null "
             ">/data/local/tmp/phantom-frida-test/server.log 2>&1"
         ),
     ]
+
+
+def test_run_command_redacts_authentication_token(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        android_smoke.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "", ""),
+    )
+
+    android_smoke.run_command(
+        ["client", "--options=origin,token=secret-token"],
+        redact=("secret-token",),
+    )
+
+    output = capsys.readouterr().out
+    assert "secret-token" not in output
+    assert "<redacted>" in output
+
+
+def test_adb_forward_targets_abstract_socket(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        android_smoke,
+        "adb",
+        lambda *args, **kwargs: calls.append((*args, kwargs)),
+    )
+
+    android_smoke._configure_forward("SERIAL-1", 27142, "oemcodec-server-a1b2c3")
+
+    assert calls == [
+        ("SERIAL-1", "forward", "--remove", "tcp:27142", {"check": False}),
+        ("SERIAL-1", "forward", "tcp:27142", "localabstract:oemcodec-server-a1b2c3", {}),
+    ]
+
+
+def test_gadget_config_uses_authenticated_abstract_socket() -> None:
+    endpoint = android_smoke.RemoteEndpoint(
+        socket="oemcodec-gadget-a1b2c3",
+        origin="https://a1b2c3.invalid",
+        token="secret-token",
+    )
+
+    config = android_smoke._gadget_interaction(endpoint)
+
+    assert config == {
+        "type": "listen",
+        "address": "unix:oemcodec-gadget-a1b2c3",
+        "origin": "https://a1b2c3.invalid",
+        "token": "secret-token",
+        "on_load": "resume",
+    }
+    assert "port" not in config
 
 
 def test_validate_config_normalizes_builder_inputs(tmp_path: Path) -> None:
@@ -135,24 +279,47 @@ def test_remote_device_retry_does_not_register_duplicate_endpoint(
     class FakeManager:
         calls = 0
         device = FakeDevice()
+        options: dict[str, str] = {}
 
-        def add_remote_device(self, _address: str) -> FakeDevice:
+        def add_remote_device(self, _address: str, **options: str) -> FakeDevice:
             self.calls += 1
+            self.options = options
             return self.device
 
     manager = FakeManager()
     monkeypatch.setattr(android_smoke.time, "sleep", lambda _seconds: None)
 
-    device, processes = android_smoke._wait_for_remote_device(manager, "127.0.0.1:27142", timeout=1)
+    endpoint = android_smoke.RemoteEndpoint(
+        socket="oemcodec-server-a1b2c3",
+        origin="https://a1b2c3.invalid",
+        token="secret-token",
+    )
+    device, processes = android_smoke._wait_for_remote_device(
+        manager,
+        "127.0.0.1:27142",
+        endpoint,
+        timeout=1,
+    )
 
     assert device is manager.device
     assert processes == ["process"]
     assert manager.calls == 1
+    assert manager.options == {
+        "origin": "https://a1b2c3.invalid",
+        "token": "secret-token",
+    }
 
 
 def test_gadget_acceptance_loads_script_and_detaches() -> None:
     class FakeScript:
         callback: object = None
+
+        class Exports:
+            @staticmethod
+            def add(left: int, right: int) -> int:
+                return left + right
+
+        exports_sync = Exports()
 
         def on(self, _event: str, callback: object) -> None:
             self.callback = callback
@@ -295,6 +462,8 @@ def test_acceptance_agent_uses_frida_17_file_and_java_wrapper_apis() -> None:
     assert ".readAllText()" not in source
     assert source.count("File.readAllText(") == 2
     assert "Java.cast(iterator.next(), Thread).getName()" in source
+    assert "rpc.exports" in source
+    assert "add(left, right)" in source
 
 
 def test_report_writer_omits_device_serial(tmp_path: Path) -> None:
@@ -308,3 +477,18 @@ def test_report_writer_omits_device_serial(tmp_path: Path) -> None:
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert report["status"] == "passed"
     assert "device_serial" not in report
+
+
+def test_cleanup_removes_remote_test_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    root_commands: list[str] = []
+    monkeypatch.setattr(
+        android_smoke,
+        "root_shell",
+        lambda _serial, command, **_kwargs: root_commands.append(command),
+    )
+    monkeypatch.setattr(android_smoke, "adb", lambda *_args, **_kwargs: None)
+    config = SimpleNamespace(name="oemcodec", port=27142)
+
+    android_smoke._cleanup(config, "SERIAL-1")
+
+    assert root_commands[-1] == "rm -rf -- /data/local/tmp/phantom-frida-test"

--- a/tests/test_android_smoke.py
+++ b/tests/test_android_smoke.py
@@ -131,6 +131,27 @@ def test_require_single_device_returns_only_authorized_serial() -> None:
     assert android_smoke.require_single_device(output) == "SERIAL-1"
 
 
+def test_interactive_device_preflight_accepts_unlocked_screen() -> None:
+    android_smoke.assert_interactive_device(
+        "mWakefulness=Awake\n",
+        "mInputRestricted=false\n",
+    )
+
+
+@pytest.mark.parametrize(
+    ("power", "policy", "reason"),
+    [
+        ("mWakefulness=Dozing\n", "mInputRestricted=false\n", "awake"),
+        ("mWakefulness=Awake\n", "mInputRestricted=true\n", "unlocked"),
+    ],
+)
+def test_interactive_device_preflight_rejects_blocked_spawn_state(
+    power: str, policy: str, reason: str
+) -> None:
+    with pytest.raises(android_smoke.SmokeFailure, match=reason):
+        android_smoke.assert_interactive_device(power, policy)
+
+
 @pytest.mark.parametrize(
     "output,count",
     [

--- a/tests/test_android_smoke.py
+++ b/tests/test_android_smoke.py
@@ -561,6 +561,8 @@ def test_cleanup_removes_remote_test_directory(monkeypatch: pytest.MonkeyPatch) 
 
     android_smoke._cleanup(config, "SERIAL-1")
 
+    assert "pkill -TERM -x oemcodec-server" in root_commands
+    assert "pkill -TERM -x gadget-loader" in root_commands
     assert "rm -rf -- /data/local/tmp/phantom-frida-test" in root_commands
     assert ("forward", "--list") in adb_commands
 
@@ -625,3 +627,50 @@ def test_cleanup_rejects_lingering_forward(monkeypatch: pytest.MonkeyPatch) -> N
 
     with pytest.raises(android_smoke.SmokeFailure, match="forward remains"):
         android_smoke._cleanup(config, "SERIAL-1")
+
+
+def test_cleanup_rejects_lingering_runtime_socket(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_root_shell(_serial: str, command: str, **_kwargs: object) -> SimpleNamespace:
+        stdout = "@/oemcodec-zymbiote-deadbeef\n" if command == "cat /proc/net/unix" else ""
+        return SimpleNamespace(
+            returncode=1 if command.startswith(("pkill", "pgrep")) else 0,
+            stdout=stdout,
+            stderr="",
+        )
+
+    monkeypatch.setattr(android_smoke, "root_shell", fake_root_shell)
+    monkeypatch.setattr(
+        android_smoke,
+        "adb",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    config = SimpleNamespace(name="oemcodec", port=27142)
+
+    with pytest.raises(android_smoke.SmokeFailure, match="unix socket remains"):
+        android_smoke._cleanup(config, "SERIAL-1")
+
+
+def test_cleanup_uses_kernel_comm_limit_for_long_server_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_commands: list[str] = []
+
+    def fake_root_shell(_serial: str, command: str, **_kwargs: object) -> SimpleNamespace:
+        root_commands.append(command)
+        return SimpleNamespace(
+            returncode=1 if command.startswith(("pkill", "pgrep")) else 0,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(android_smoke, "root_shell", fake_root_shell)
+    monkeypatch.setattr(
+        android_smoke,
+        "adb",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    config = SimpleNamespace(name="abcdefghijklmnopqrst", port=27142)
+
+    android_smoke._cleanup(config, "SERIAL-1")
+
+    assert "pkill -TERM -x abcdefghijklmno" in root_commands

--- a/tests/test_android_smoke.py
+++ b/tests/test_android_smoke.py
@@ -25,6 +25,20 @@ def test_proc_scan_accepts_custom_runtime_names() -> None:
     )
 
 
+def test_proc_scan_rejects_legacy_linjector_fd() -> None:
+    with pytest.raises(android_smoke.SmokeFailure, match="linjector"):
+        android_smoke.assert_clean_proc_text("fds", "pipe:[linjector-123]")
+
+
+def test_proc_scan_rejects_active_tracer() -> None:
+    with pytest.raises(android_smoke.SmokeFailure, match="TracerPid"):
+        android_smoke.assert_clean_proc_text("status", "Name:\ttarget\nTracerPid:\t123\n")
+
+
+def test_proc_scan_accepts_no_tracer() -> None:
+    android_smoke.assert_clean_proc_text("status", "Name:\ttarget\nTracerPid:\t0\n")
+
+
 @pytest.mark.parametrize(
     "marker",
     [
@@ -61,13 +75,14 @@ def test_proc_scan_uses_portable_single_commands(monkeypatch: pytest.MonkeyPatch
         "memfd:jit-code-cache",
     )
 
-    assert commands[:4] == [
+    assert commands[:5] == [
         "cat /proc/net/unix",
         "cat /proc/123/maps",
         "ls -l /proc/123/fd",
+        "cat /proc/123/status",
         "cat /proc/123/task/*/comm",
     ]
-    assert commands[4].startswith(
+    assert commands[5].startswith(
         "/data/local/tmp/phantom-frida-test/proc-memory-scanner 123 memfd:jit-code-cache"
     )
     assert report == {"ranges": 7, "executable": 3}

--- a/tests/test_build_invariants.py
+++ b/tests/test_build_invariants.py
@@ -1,3 +1,5 @@
+import gzip
+import struct
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -6,12 +8,88 @@ import pytest
 import build
 
 
+def make_elf64_with_alloc_and_debug_sections(alloc: bytes, debug: bytes) -> bytes:
+    alloc_offset = 0x100
+    debug_offset = 0x200
+    section_table_offset = 0x300
+    section_header_size = 64
+    data = bytearray(section_table_offset + (3 * section_header_size))
+    data[:16] = b"\x7fELF\x02\x01\x01" + (b"\0" * 9)
+    struct.pack_into("<Q", data, 0x28, section_table_offset)
+    struct.pack_into("<H", data, 0x3A, section_header_size)
+    struct.pack_into("<H", data, 0x3C, 3)
+    data[alloc_offset : alloc_offset + len(alloc)] = alloc
+    data[debug_offset : debug_offset + len(debug)] = debug
+    struct.pack_into(
+        "<IIQQQQIIQQ",
+        data,
+        section_table_offset + section_header_size,
+        0,
+        1,
+        2,
+        0,
+        alloc_offset,
+        len(alloc),
+        0,
+        0,
+        1,
+        0,
+    )
+    struct.pack_into(
+        "<IIQQQQIIQQ",
+        data,
+        section_table_offset + (2 * section_header_size),
+        0,
+        1,
+        0,
+        0,
+        debug_offset,
+        len(debug),
+        0,
+        0,
+        1,
+        0,
+    )
+    return bytes(data)
+
+
 def test_verify_binary_rejects_known_runtime_markers(tmp_path: Path) -> None:
     binary = tmp_path / "server"
     binary.write_bytes(b"prefix\x00/frida-zymbiote-123\x00re/frida/HelperBackend\x00")
 
     with pytest.raises(build.BuildError, match="frida-zymbiote"):
         build.verify_binary(binary)
+
+
+def test_verify_binary_rejects_modern_memory_and_thread_markers(tmp_path: Path) -> None:
+    binary = tmp_path / "server"
+    binary.write_bytes(
+        b"FridaScriptEngine\0GLib-GIO\0GDBusProxy\0GumScript\0frida:rpc\0"
+        b"frida-gadget\0frida-eternal-agent\0frida-main-loop\0Frida/17.16.3\0"
+    )
+
+    with pytest.raises(build.BuildError, match="FridaScriptEngine"):
+        build.verify_binary(binary)
+
+
+def test_verify_binary_allows_required_stock_protocol_identifiers(tmp_path: Path) -> None:
+    binary = tmp_path / "server"
+    binary.write_bytes(b"Frida\0re.frida.HostSession\0re.frida.GadgetSession\0")
+
+    build.verify_binary(binary)
+
+
+def test_binary_memory_patches_only_touch_runtime_alloc_sections(tmp_path: Path) -> None:
+    markers = b"FridaScriptEngine\0GLib-GIO\0GDBusProxy\0GumScript\0"
+    binary = tmp_path / "agent.so"
+    binary.write_bytes(make_elf64_with_alloc_and_debug_sections(markers, markers))
+
+    build.apply_binary_patches(binary, "oemcodec", extended=True)
+
+    patched = binary.read_bytes()
+    assert markers not in patched[0x100 : 0x100 + len(markers)]
+    assert patched[0x200 : 0x200 + len(markers)] == markers
+    assert len(patched) == len(make_elf64_with_alloc_and_debug_sections(markers, markers))
 
 
 def test_collect_artifacts_requires_server_and_gadget(tmp_path: Path) -> None:
@@ -69,6 +147,60 @@ def test_collect_artifacts_returns_only_verified_staged_outputs(tmp_path: Path) 
         "oemcodec-gadget-17.16.3-android-arm64.so.gz",
     }
     assert not list(output_dir.glob(".staging-*"))
+
+
+def test_strip_binary_uses_llvm_strip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    binary = tmp_path / "gadget.so"
+    binary.write_bytes(b"gadget")
+    strip_tool = tmp_path / "llvm-strip"
+    commands: list[list[object]] = []
+    monkeypatch.setattr(
+        build,
+        "run",
+        lambda command, **_kwargs: commands.append(list(command)),
+    )
+
+    build.strip_binary(binary, strip_tool)
+
+    assert commands == [[strip_tool, "--strip-unneeded", binary]]
+
+
+def test_collect_artifacts_strips_only_staged_gadget_before_compression(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core_build = tmp_path / "build/subprojects/frida-core"
+    server_dir = core_build / "server"
+    gadget_dir = core_build / "lib/gadget"
+    server_dir.mkdir(parents=True)
+    gadget_dir.mkdir(parents=True)
+    server_source = server_dir / "oemcodec-server"
+    gadget_source = gadget_dir / "liboemcodec-gadget.so"
+    server_source.write_bytes(b"clean-server")
+    gadget_source.write_bytes(b"unstripped-gadget")
+    stripped: list[Path] = []
+
+    def fake_strip(binary: Path, _tool: Path) -> None:
+        stripped.append(binary)
+        binary.write_bytes(b"stripped-gadget")
+
+    monkeypatch.setattr(build, "strip_binary", fake_strip)
+    output_dir = tmp_path / "stage"
+
+    build.collect_artifacts(
+        tmp_path,
+        "android-arm64",
+        "oemcodec",
+        "17.16.3",
+        output_dir,
+        True,
+        strip_tool=tmp_path / "llvm-strip",
+    )
+
+    gadget_output = output_dir / "oemcodec-gadget-17.16.3-android-arm64.so"
+    assert [path.name for path in stripped] == [gadget_output.name]
+    assert gadget_output.read_bytes() == b"stripped-gadget"
+    assert gzip.decompress(gadget_output.with_suffix(".so.gz").read_bytes()) == b"stripped-gadget"
+    assert gadget_source.read_bytes() == b"unstripped-gadget"
 
 
 def test_collect_artifacts_does_not_promote_failed_stage(tmp_path: Path) -> None:

--- a/tests/test_build_invariants.py
+++ b/tests/test_build_invariants.py
@@ -92,6 +92,22 @@ def test_binary_memory_patches_only_touch_runtime_alloc_sections(tmp_path: Path)
     assert len(patched) == len(make_elf64_with_alloc_and_debug_sections(markers, markers))
 
 
+def test_binary_replacement_does_not_cross_protected_region_boundary() -> None:
+    data = b"prefix-frida-suffix"
+    marker_start = data.index(b"frida")
+
+    patched, count = build.replace_bytes_in_regions(
+        data,
+        b"frida",
+        b"libgc",
+        [(0, len(data))],
+        [(marker_start + 2, marker_start + 4)],
+    )
+
+    assert patched == data
+    assert count == 0
+
+
 def test_collect_artifacts_requires_server_and_gadget(tmp_path: Path) -> None:
     with pytest.raises(build.BuildError, match="Server artifact"):
         build.collect_artifacts(
@@ -163,6 +179,14 @@ def test_strip_binary_uses_llvm_strip(tmp_path: Path, monkeypatch: pytest.Monkey
     build.strip_binary(binary, strip_tool)
 
     assert commands == [[strip_tool, "--strip-unneeded", binary]]
+
+
+def test_find_llvm_strip_accepts_linux_ndk_tool(tmp_path: Path) -> None:
+    strip_tool = tmp_path / "toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip"
+    strip_tool.parent.mkdir(parents=True)
+    strip_tool.write_bytes(b"")
+
+    assert build.find_llvm_strip(tmp_path) == strip_tool
 
 
 def test_collect_artifacts_strips_only_staged_gadget_before_compression(

--- a/tests/test_patch_contracts.py
+++ b/tests/test_patch_contracts.py
@@ -114,6 +114,14 @@ def make_core_fixture(tmp_path: Path) -> Path:
         "subprojects/frida-core/src/frida-glue.c": (
             'main_thread = g_thread_new ("frida-main-loop", run_main_loop, NULL);\n'
         ),
+        "subprojects/frida-core/src/host-session-service.vala": (
+            'e = new Error.PROCESS_NOT_RESPONDING ("Process with pid %u either refused to load '
+            'frida-agent, " +\n'
+            '    "or terminated during injection", pid);\n'
+        ),
+        "subprojects/frida-gum/bindings/gumjs/guminspectorserver.c": (
+            'json_builder_add_string_value (builder, "Frida/v" FRIDA_VERSION);\n'
+        ),
         "subprojects/frida-core/lib/payload/portal-client.vala": (
             'throw new Error.NOT_SUPPORTED ("unsupported by frida-gadget");\n'
         ),
@@ -188,6 +196,7 @@ def test_required_patches_remove_runtime_rpc_branding_and_thread_markers(tmp_pat
     )
     for marker in (
         "frida:rpc",
+        "frida-agent",
         "frida-gadget",
         "frida-eternal-agent",
         "frida-generate-certificate",

--- a/tests/test_patch_contracts.py
+++ b/tests/test_patch_contracts.py
@@ -50,6 +50,85 @@ def make_core_fixture(tmp_path: Path) -> Path:
         (FIXTURE_DIR / "gumexceptor-posix.c").read_text(encoding="utf-8"),
         encoding="utf-8",
     )
+
+    runtime_sources = {
+        "subprojects/frida-core/lib/base/rpc.vala": """namespace Frida {
+\tpublic sealed class RpcClient : Object {
+\t\tvoid build_request (Json.Builder request) {
+\t\t\trequest.add_string_value (\"frida:rpc\");
+\t\t}
+\t\tbool inspect (string json, string? type) {
+\t\t\tif (json.index_of (\"\\\"frida:rpc\\\"\") == -1)
+\t\t\t\treturn false;
+\t\t\tif (type == null || type != \"frida:rpc\")
+\t\t\t\treturn false;
+\t\t\treturn true;
+\t\t}
+\t\tprivate class PendingResponse {
+\t\t}
+\t}
+}
+""",
+        "subprojects/frida-core/src/barebone/script-runtime/message-dispatcher.ts": (
+            "export class MessageDispatcher {\n"
+            "  dispatch(message) {\n"
+            '    if (message[0] === "frida:rpc") {\n'
+            '      send(["frida:rpc"]);\n'
+            '      send(["frida:rpc"]);\n'
+            "    }\n"
+            "  }\n"
+            "}\n"
+        ),
+        "subprojects/frida-gum/bindings/gumjs/runtime/message-dispatcher.js": (
+            "export function MessageDispatcher() {\n"
+            "  if (message[0] === 'frida:rpc') {\n"
+            "    send(['frida:rpc']);\n"
+            "    send(['frida:rpc']);\n"
+            "    send(['frida:rpc']);\n"
+            "  }\n"
+            "}\n"
+        ),
+        "subprojects/frida-gum/bindings/gumjs/runtime/worker.js": (
+            "export class Worker {\n"
+            "  request(payload) {\n"
+            "    if (payload[0] === 'frida:rpc') this.post(['frida:rpc']);\n"
+            "  }\n"
+            "}\n"
+        ),
+        "subprojects/frida-core/lib/gadget/gadget-glue.c": (
+            'worker_thread = g_thread_new ("frida-gadget", run_worker_loop, NULL);\n'
+        ),
+        "subprojects/frida-core/lib/gadget/gadget.vala": (
+            'Environment.set_thread_name ("frida-gadget-tcp-%u".printf (listen_port));\n'
+            'Environment.set_thread_name ("frida-gadget-unix");\n'
+        ),
+        "subprojects/frida-core/lib/agent/agent.vala": (
+            'new Thread<bool> ("frida-eternal-agent", callback);\n' * 3
+        ),
+        "subprojects/frida-core/lib/base/p2p.vala": (
+            'new Thread<bool> ("frida-generate-certificate", callback);\n'
+        ),
+        "subprojects/frida-core/lib/base/socket.vala": (
+            'headers.replace ("User-Agent", "Frida/" + version);\n' * 3
+        ),
+        "subprojects/frida-core/src/frida-glue.c": (
+            'main_thread = g_thread_new ("frida-main-loop", run_main_loop, NULL);\n'
+        ),
+        "subprojects/frida-core/lib/payload/portal-client.vala": (
+            'throw new Error.NOT_SUPPORTED ("unsupported by frida-gadget");\n'
+        ),
+        "subprojects/frida-core/src/droidy/injector.vala": (
+            'string so_path = "/data/local/tmp/frida-gadget-id.so";\n'
+            'string config_path = "/data/local/tmp/frida-gadget-id.config";\n'
+        ),
+        "subprojects/frida-core/src/droidy/droidy-host-session.vala": (
+            'throw new Error.NOT_SUPPORTED ("frida-gadget.so to use");\n'
+        ),
+    }
+    for relative_path, content in runtime_sources.items():
+        target = tmp_path / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
     return tmp_path
 
 
@@ -97,6 +176,44 @@ def test_required_patch_fails_when_upstream_contract_drifts(tmp_path: Path) -> N
 
     with pytest.raises(build.BuildError, match="re/frida/HelperBackend"):
         build.apply_required_file_patches(root, "oemcodec")
+
+
+def test_required_patches_remove_runtime_rpc_branding_and_thread_markers(tmp_path: Path) -> None:
+    root = make_core_fixture(tmp_path)
+
+    build.apply_required_file_patches(root, "oemcodec")
+
+    combined = "\n".join(
+        path.read_text(encoding="utf-8") for path in root.rglob("*.*") if path.is_file()
+    )
+    for marker in (
+        "frida:rpc",
+        "frida-gadget",
+        "frida-eternal-agent",
+        "frida-generate-certificate",
+        "frida-main-loop",
+        "Frida/",
+    ):
+        assert marker not in combined
+    assert "String.fromCharCode(102, 114, 105, 100, 97, 58, 114, 112, 99)" in combined
+    assert "make_rpc_tag" in combined
+    assert "oemcodec-gadget" in combined
+    assert "Oemcodec/" in combined
+
+
+def test_targeted_patch_uses_non_counted_art_jit_memfd_name(tmp_path: Path) -> None:
+    root = make_core_fixture(tmp_path)
+    linux = root / "subprojects/frida-core/lib/base/linux.vala"
+    linux.write_text(
+        "return Linux.syscall (LinuxSyscall.MEMFD_CREATE, name, flags);\n",
+        encoding="utf-8",
+    )
+
+    build.apply_targeted_patches(root, "oemcodec", 17)
+
+    patched = linux.read_text(encoding="utf-8")
+    assert '"jit-code-cache"' in patched
+    assert '"jit-cache"' not in patched
 
 
 def test_zymbiote_artifacts_patch_the_fixed_socket_field(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

- remove contiguous `frida:rpc`, current Server/Gadget/agent thread names, HTTP/Inspector branding, and four mapped runtime signatures while preserving the stock protocol
- use the Android-compatible `jit-code-cache` memfd name and restrict post-link byte patches to file-backed `SHF_ALLOC` sections outside DEX
- strip staged Gadget artifacts before compression and the hard marker gate
- run Server and Gadget through separate randomized authenticated abstract-UNIX sockets with ADB forwarding only
- verify stock RPC and scan mapped agent/Gadget memory from an external rooted process
- make rooted-device cleanup PID-scoped to exact test executables, graceful-first, and independently verifiable

## Why

The previous build passed its narrow marker gate but retained several signatures visible to modern Android detectors, exposed a device TCP listener during acceptance, and did not inspect memory independently of Frida's own cloaked process view.

## Validation

- `139 passed` with coverage
- Ruff lint and format checks
- mypy on `build.py patches.py namegen.py scripts`
- JavaScript and shell syntax checks
- actionlint 1.7.12
- C memory probe compiled with NDK r29 for arm64, arm, x86_64, and x86
- clean Frida 17.16.3 arm64 CI build completed; Server and stripped Gadget passed the expanded hard marker gate
- `SHA256SUMS` verified all four generated binary assets
- physical rooted Android 14 acceptance passed for Server, Java spawn/attach/resume, and separately loaded Gadget using the unmodified Frida 17.16.3 Python client
- external Server and Gadget scans each inspected 9 readable ranges (7 executable), with zero matches for all 14 runtime markers; `/proc` checks also found no active tracer or `linjector` descriptor
- independent cleanup verification found no test PID, directory, Unix socket, open file, or ADB forward

Detailed physical-test evidence and artifact hashes are recorded in [`docs/testing/android-17.16.3.md`](docs/testing/android-17.16.3.md).

## Scope

Stock-client compatibility identifiers (`Frida\0`, `re.frida.*`, `GadgetSession`) remain intentionally preserved. Root, automated launch, instrumentation side-effects, active probing, code integrity, and remote attestation are outside a renamed runtime's guarantees. Android 15 issue #5 remains open until tested on Android 15 hardware.